### PR TITLE
fix #21 linux 启动报错 fs 权限配置问题

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -21,6 +21,10 @@
     "store:allow-load",
     "fs:default",
     {
+      "identifier": "fs:scope",
+      "allow": [{ "path": "$APPDATA" }, { "path": "$APPDATA/**" }]
+    },
+    {
       "identifier": "fs:read-all",
       "allow": [
         {


### PR DESCRIPTION
fix #21 添加配置允许对 $APPDATA 目录有所有 fs 权限

权限配置参考：https://v2.tauri.app/plugin/file-system/#examples