### PR TITLE
fix(#24) 未设置github帐号时,不显示顶部同步header

### DIFF
--- a/src/app/core/image/image-header.tsx
+++ b/src/app/core/image/image-header.tsx
@@ -1,38 +1,43 @@
 "use client"
-import { TooltipButton } from "@/components/tooltip-button"
-import { TooltipProvider } from "@/components/ui/tooltip"
-import { Link, RefreshCcw } from "lucide-react"
+import {TooltipButton} from "@/components/tooltip-button"
+import {TooltipProvider} from "@/components/ui/tooltip"
+import {Link, RefreshCcw} from "lucide-react"
 import * as React from "react"
 import useImageStore from "@/stores/image"
-import { Separator } from "@/components/ui/separator"
-import { convertBytesToSize } from "@/lib/utils"
-import { open } from '@tauri-apps/plugin-shell';
+import {Separator} from "@/components/ui/separator"
+import {convertBytesToSize} from "@/lib/utils"
+import {open} from '@tauri-apps/plugin-shell';
 import useSettingStore from "@/stores/setting"
 
+
 export function ImageHeader() {
-  const { getImages, images } = useImageStore()
-  const { githubUsername } = useSettingStore()
+  const {getImages, images} = useImageStore()
+  const {githubUsername} = useSettingStore()
+  const checkSetting = githubUsername && githubUsername.length > 0
   const handleOpenBroswer = () => {
     const url = `https://github.com/${githubUsername}/note-gen-image-sync`
     open(url)
   }
 
   return (
-    <header className="h-12 flex items-center justify-between gap-2 border-b px-4 bg-primary-foreground">
-      <div className="flex items-center h-6 gap-1">
-        <TooltipButton icon={<Link />} tooltipText="打开仓库" onClick={handleOpenBroswer} />
-      </div>
-      <div className="flex items-center h-6 gap-1">
-        <TooltipProvider>
-          <div className="flex items-center h-6 gap-1">
-            <span className="text-sm px-2">{images.length} 个文件</span>
-            <Separator orientation="vertical" />
-            <span className="text-sm px-2">总大小：{convertBytesToSize(images.reduce((total, image) => total + image.size, 0))}</span>
-            <Separator orientation="vertical" />
-          </div>
-          <TooltipButton icon={<RefreshCcw />} tooltipText="刷新" onClick={getImages} />
-        </TooltipProvider>
-      </div>
-    </header>
+    checkSetting ? (
+      <header className="h-12 flex items-center justify-between gap-2 border-b px-4 bg-primary-foreground">
+        <div className="flex items-center h-6 gap-1">
+          <TooltipButton icon={<Link/>} tooltipText="打开仓库" onClick={handleOpenBroswer}/>
+        </div>
+        <div className="flex items-center h-6 gap-1">
+          <TooltipProvider>
+            <div className="flex items-center h-6 gap-1">
+              <span className="text-sm px-2">{images.length} 个文件</span>
+              <Separator orientation="vertical"/>
+              <span
+                className="text-sm px-2">总大小：{convertBytesToSize(images.reduce((total, image) => total + image.size, 0))}</span>
+              <Separator orientation="vertical"/>
+            </div>
+            <TooltipButton icon={<RefreshCcw/>} tooltipText="刷新" onClick={getImages}/>
+          </TooltipProvider>
+        </div>
+      </header>
+    ) : <></>
   )
 }

--- a/src/app/core/image/no-data.tsx
+++ b/src/app/core/image/no-data.tsx
@@ -5,7 +5,7 @@ export function NoData() {
   const router = useRouter();
 
   function handelRouteToSetting() {
-    router.push('/core/setting?anchor=file', { scroll: false });
+    router.push('/core/setting?anchor=sync', { scroll: false });
   }
 
   return (

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -104,7 +104,12 @@ export async function getFiles({ path, repo }: { path: string, repo: RepoNames }
     return res.data;
   } catch (error) {
     console.log(error);
-    return false
+    toast({
+      title: '同步失败',
+      description: '请检查网络或配置是否正确。',
+      variant: 'destructive',
+    })
+    return [];
   }
 }
 


### PR DESCRIPTION
做了点相关的优化,对现在的前端不太熟悉,还停留在以前的jq时代,毕竟40+了
公司机器有点旧(7770),在dev模式下无法显示窗口内容(GT-720,NV驱动的问题),只能build后测试了

1.未设置gh相关信息时,不显示跟同步相关的信息
![image](https://github.com/user-attachments/assets/e259cbb2-b857-4292-89b6-a757f2033812)
2.点击"前往设置"时,准确跳转到"同步"选项
![image](https://github.com/user-attachments/assets/fa404b10-4357-4c61-b604-18a35a1880cb)
