### PR TITLE
Fix(#136): 0.13.1版本win10默认存储区域无法找到文件

### DIFF
--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -95,9 +95,9 @@ export async function getGenericPathOptions(path: string, prefix?: string): Prom
 export async function toWorkspaceRelativePath(path: string): Promise<string> {
   const workspace = await getWorkspacePath()
   
-  const isDefaultDirRegex = /^(article[\\\/])/
+  const defaultDirRegex = /^(article[\\\/])/
   // 如果是默认工作区，移除"article/"前缀
-  if (!workspace.isCustom && isDefaultDirRegex.test(path)) {
+  if (!workspace.isCustom && defaultDirRegex.test(path)) {
     return path.replace(/article[\\\/]/g, '')
   }
   

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -95,9 +95,10 @@ export async function getGenericPathOptions(path: string, prefix?: string): Prom
 export async function toWorkspaceRelativePath(path: string): Promise<string> {
   const workspace = await getWorkspacePath()
   
+  const isDefaultDirRegex = /^(article[\\\/])/
   // 如果是默认工作区，移除"article/"前缀
-  if (!workspace.isCustom && path.startsWith('article/')) {
-    return path.replace('article/', '')
+  if (!workspace.isCustom && isDefaultDirRegex.test(path)) {
+    return path.replace(/article[\\\/]/g, '')
   }
   
   // 如果是自定义工作区，移除工作区路径前缀


### PR DESCRIPTION
将原来硬编码的判断默认文件夹方式改成对应的正则方式判断和替换，不论是linux还是win10的分隔符都支持