### PR TITLE
Sync clipboard monitor state with `store.json` on mount

### DIFF
--- a/src/app/core/record/chat/clipboard-monitor.tsx
+++ b/src/app/core/record/chat/clipboard-monitor.tsx
@@ -2,12 +2,32 @@
 import { useTranslations } from 'next-intl'
 import { Clipboard, ClipboardX } from 'lucide-react'
 import { TooltipButton } from '@/components/tooltip-button'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Store } from '@tauri-apps/plugin-store'
 
 export function ClipboardMonitor() {
   const t = useTranslations('record.chat.input.clipboardMonitor')
   const [isEnabled, setIsEnabled] = useState(true)
+  
+  // Sync with store.json on mount
+  useEffect(() => {
+    const syncWithStore = async () => {
+      try {
+        const store = await Store.load('store.json')
+        const storedValue = await store.get<boolean>('clipboardMonitor')
+        
+        // Only update if the stored value exists and is different from the current state
+        if (storedValue !== undefined && storedValue !== isEnabled) {
+          setIsEnabled(storedValue)
+        }
+      } catch (error) {
+        console.error('Failed to load clipboard monitor state from store:', error)
+      }
+    }
+    
+    syncWithStore()
+  }, [])
+  
 
   const toggleClipboardMonitor = async () => {
     const newState = !isEnabled


### PR DESCRIPTION
现在 NoteGen 启动的时候默认 clipboard monitor 显示为开启状态，应该 respect `store.json` 里的设置才好吧。