### PR TITLE
fix(#244): error in render when using Q&A after inserting content from record 

### DIFF
--- a/src/app/core/article/custom-toolbar/question.tsx
+++ b/src/app/core/article/custom-toolbar/question.tsx
@@ -31,7 +31,22 @@ export default function Question({editor}: {editor?: Vditor}) {
   }
 
   useEffect(() => {
-    emitter.on('toolbar-question', handleBlock)
+    // Ignore subsequence emits while function handleBock is running
+    let running = false
+    const guardedHandler = async () => {
+      if (running) return
+      running = true
+      try {
+        await handleBlock()
+      } finally {
+        running = false
+      }
+    }
+
+    emitter.on('toolbar-question', guardedHandler)
+    return () => {
+      emitter.off('toolbar-question', guardedHandler)
+    }
   }, [])
   return (
     <TooltipButton disabled={!apiKey} icon={<MessageCircleQuestion />} tooltipText={t('tooltip')} onClick={handleBlock}>


### PR DESCRIPTION
Although this issue is closed, based on my testing on a Mac computer, this problem persist when I try to use Q&A after inserting content from the record. Based on my observation, the render error happened when the function handleBlock is called twice consecutively. Therefore, I added a gaurdedHandler that ignore subsequence emits while function handleBlock is running.