### PR TITLE
fix(#432)切换或打开文件,未正确渲染.

### DIFF
--- a/src/app/core/article/md-editor.tsx
+++ b/src/app/core/article/md-editor.tsx
@@ -248,6 +248,7 @@ export function MdEditor() {
     if (!editor) return
     editor.setValue(content)
     editor.renderPreview(content)
+    editor.insertValue('')
     
     // 如果有匹配位置，滚动到对应位置
     if (matchPosition !== null) {


### PR DESCRIPTION
多次测试发现,只要输入一点东西,就会渲染.
在设置内容时,插入空字符,也会触发渲染.更底层原因,由于本人技术原因,未进行太深入