### PR TITLE
support xinference rerank response format

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -285,7 +285,7 @@ export async function rerankDocuments(
     // 将原始文档与新的相似度分数结合
     const rerankResults = data.results.map((result: any, index: number) => {
       return {
-        ...documents[result.document_index || index],
+        ...documents[result.document_index || result.index || index],
         similarity: result.relevance_score || result.score || documents[index].similarity
       };
     });


### PR DESCRIPTION
support field "index" in rerank response "results"
issue: https://github.com/codexu/note-gen/issues/477

xinference rerank format sample:
{
  "id": "7ea4e32a-6acf-11f0-af6e-fc3497b65dcb",
  "results": [
    {
      "index": 0,
      "relevance_score": 0.019732829183340073,
      "document": null
    },
    {
      "index": 1,
      "relevance_score": 0.0012231824221089482,
      "document": null
    }
  ],
  "meta": {
    "api_version": null,
    "billed_units": null,
    "tokens": null,
    "warnings": null
  }
}