### PR TITLE
feat: 增加AI配置自定义请求头功能

### DIFF
--- a/src/app/core/setting/ai/page.tsx
+++ b/src/app/core/setting/ai/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { FormItem, SettingRow, SettingType } from "../components/setting-base";
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from "react";
@@ -44,6 +45,7 @@ export default function AiPage() {
   const [topP, setTopP] = useState<number>(1.0)
   const [modelType, setModelType] = useState<ModelType>('chat')
   const [apiKeyVisible, setApiKeyVisible] = useState<boolean>(false)
+  const [customHeaders, setCustomHeaders] = useState<string>('')
 
   // 通过本地存储查询当前的模型配置
   async function getModelByStore(key: string) {
@@ -67,6 +69,7 @@ export default function AiPage() {
     setTemperature(model.temperature || 0.7)
     setTopP(model.topP || 0.1)
     setModelType(model.modelType || 'chat')
+    setCustomHeaders(model.customHeaders ? JSON.stringify(model.customHeaders, null, 2) : '{}')
   }
 
   // 数据变化保存
@@ -94,6 +97,9 @@ export default function AiPage() {
         break;
       case 'modelType':
         setModelType(value as ModelType)
+        break;
+      case 'customHeaders':
+        setCustomHeaders(JSON.stringify(value, null, 2))
         break;
     }
     const model = await getModelByStore(currentAi)
@@ -282,6 +288,28 @@ export default function AiPage() {
             </RadioGroup>
           </FormItem>
         </SettingRow>
+        {/* 自定义Headers */}
+        {!baseAiConfig.find(config => config.baseURL === baseURL) && (
+          <SettingRow>
+            <FormItem title="自定义Headers" desc="自定义请求头 (JSON格式)">
+              <Textarea
+                value={customHeaders}
+                onChange={(e) => {
+                  setCustomHeaders(e.target.value)
+                }}
+                onBlur={(e) => {
+                  try {
+                    const headers = JSON.parse(e.target.value || '{}')
+                    valueChangeHandler('customHeaders', headers)
+                  } catch {
+                    valueChangeHandler('customHeaders', {})
+                  }
+                }}
+                className="h-24 resize-none font-mono text-sm"
+              />
+            </FormItem>
+          </SettingRow>
+        )}
         {
           modelType === 'chat' && (
             <>

--- a/src/app/core/setting/config.tsx
+++ b/src/app/core/setting/config.tsx
@@ -93,6 +93,7 @@ export interface AiConfig {
   modelType?: ModelType
   icon?: string
   apiKeyUrl?: string
+  customHeaders?: Record<string, string>
 }
 
 export interface Model {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -364,6 +364,7 @@ export async function createOpenAIClient(AiConfig?: AiConfig) {
       "x-stainless-runtime": null,
       "x-stainless-runtime-version": null,
       "x-stainless-timeout": null,
+      ...(AiConfig?.customHeaders || {})
     },
     ...(proxyUrl ? { httpAgent: proxyUrl } : {})
   })


### PR DESCRIPTION
- 在AiConfig接口中添加customHeaders字段
- 在createOpenAIClient中合并自定义headers到默认请求头
- 在AI配置页面为自定义配置添加Headers编辑功能
- 修复自定义headers保存逻辑，改为失焦时保存
- 优化代码结构，直接在defaultHeaders中合并自定义headers

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>