### PR TITLE
fix(#444)分屏预览情况在,本地图片粘贴后,无法立即加载的问题.

### DIFF
--- a/src/app/core/article/md-editor.tsx
+++ b/src/app/core/article/md-editor.tsx
@@ -124,7 +124,10 @@ export function MdEditor() {
       input: (value) => {
         saveCurrentArticle(value)
         emitter.emit('editor-input')
-        handleLocalImage(vditor)
+        setTimeout(() => {
+          handleLocalImage(vditor)
+        }, 1100)
+
       },
       mode: localMode,
       upload: {
@@ -193,7 +196,7 @@ export function MdEditor() {
   // 处理本地相对路径图片
   async function handleLocalImage(vditor: Vditor) {
     const workspace = await getWorkspacePath()
-    const previews = [vditor.vditor.ir?.element, vditor.vditor.sv?.element, vditor.vditor.wysiwyg?.element]
+    const previews = [vditor.vditor.ir?.element, vditor.vditor.sv?.element, vditor.vditor.wysiwyg?.element,vditor.vditor.preview?.element]
     previews.forEach(element => {
       element?.querySelectorAll('img').forEach(async (img) => {
         let src = img.getAttribute('src')


### PR DESCRIPTION
增加分屏下,右侧预览的处理.vditor.vditor.preview?.element
看源码发现,分屏处理完成后,会有个1000ms延迟.会导致,重新请求图片,会报404错误,无法显示.
修改为,1100ms后,重新处理本地图片. (可以增加分屏模式判断,再执行这个.)
vditor index.js 12275行.
            else {
                var html = vditor.lute.Md2HTML(markdownText);
                if (vditor.options.preview.transform) {
                    html = vditor.options.preview.transform(html);
                }
                _this.previewElement.innerHTML = html;
                _this.afterRender(vditor, renderStartTime);
            }
        }, vditor.options.preview.delay);
