### PR TITLE
fix: 修复customHeaders输入问题，从JSON textarea改为键值对编辑器

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -343,7 +343,11 @@
       "temperatureDesc": "Controls randomness of output. Lower values make generated content more deterministic.",
       "topPDesc": "A nucleus sampling method, where the model considers the results of tokens with top_p probability mass. So 0.1 means only consider the top 10% probability mass. Usually we suggest to change this or temperature but not both.",
       "customHeaders": "Custom Headers",
-      "customHeadersDesc": "Add custom HTTP headers as JSON object. "
+      "customHeadersDesc": "Add custom HTTP headers with key-value pairs.",
+      "connectionSuccess": "AI connection test passed",
+      "headerKey": "Key",
+      "headerValue": "Value",
+      "addHeader": "Add Header"
     },
     "ocr": {
       "title": "OCR",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -341,7 +341,11 @@
       "temperatureDesc": "サンプリング温度は0から2の間で設定します。高い値（例:0.8）は出力をよりランダムに、低い値（例:0.2）はより決定的にします。通常、この値かtop_pのみを調整してください。",
       "topPDesc": "top_p（核サンプリング）は温度の代替手法です。top_p=0.1なら上位10%確率のトークンのみ考慮します。通常、この値かtemperatureのみを調整してください。",
       "customHeaders": "カスタムヘッダー",
-      "customHeadersDesc": "JSONオブジェクト形式でカスタムHTTPヘッダーを追加します。"
+      "customHeadersDesc": "キーと値のペアでカスタムHTTPヘッダーを追加します。",
+      "connectionSuccess": "AI接続テストが成功しました",
+      "headerKey": "キー",
+      "headerValue": "値",
+      "addHeader": "ヘッダーを追加"
     },
     "ocr": {
       "title": "OCR",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -325,7 +325,11 @@
       "temperatureDesc": "使用什么采样温度，介于 0 和 2 之间。较高的值（如 0.8）将使输出更加随机，而较低的值（如 0.2）将使输出更加集中和确定。 我们通常建议改变这个或top_p但不是两者。",
       "topPDesc": "一种替代温度采样的方法，称为核采样，其中模型考虑具有 top_p 概率质量的标记的结果。所以 0.1 意味着只考虑构成前 10% 概率质量的标记。 我们通常建议改变这个或temperature但不是两者。",
       "customHeaders": "自定义请求头",
-      "customHeadersDesc": "添加自定义 HTTP 请求头，格式为 JSON 对象。"
+      "customHeadersDesc": "添加自定义 HTTP 请求头，支持多个键值对配置。",
+      "headerKey": "键",
+      "headerValue": "值",
+      "addHeader": "添加 Header",
+      "connectionSuccess": "AI 连接测试通过"
     },
     "imageMethod": {
       "title": "图像识别",

--- a/src/app/core/setting/ai/check.tsx
+++ b/src/app/core/setting/ai/check.tsx
@@ -6,11 +6,13 @@ import { useEffect, useState } from "react"
 import { AiConfig } from "../config"
 import { toast } from "@/hooks/use-toast"
 import { fetch } from "@tauri-apps/plugin-http"
+import { useTranslations } from 'next-intl'
 
 // 检测当前 AI 的可用性
 export function AiCheck() {
   const [state, setState] = useState<'ok' | 'error' | 'checking' | 'init'>('init')
   const { currentAi, aiModelList } = useSettingStore()
+  const t = useTranslations('settings.ai')
 
   async function check() {
     setState('checking')
@@ -22,6 +24,10 @@ export function AiCheck() {
     const aiStatus = await checkAiStatus(model)
     if (aiStatus) {
       setState('ok')
+      toast({
+        description: t('connectionSuccess'),
+        className: 'border-green-500 bg-green-50 text-green-800'
+      })
     } else {
       setState('error')
     }


### PR DESCRIPTION
原因：textarea在macOS上会自动调整引号格式，导致JSON格式错误无法保存
顺带：补充AI连接测试成功提示，之前只有错误提示没有成功反馈
主要更改：
- 替换JSON textarea为键值对编辑器，避免智能引号问题
- 优化customHeaders数据处理，简化默认值逻辑
- 确保customHeaders变更触发模型列表刷新