### PR TITLE
fix: 修复macOS截图功能权限和错误处理问题

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -845,14 +845,38 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -3367,6 +3391,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 name = "note-gen"
 version = "0.1.0"
 dependencies = [
+ "core-graphics 0.23.2",
  "fuzzy-matcher",
  "jieba-rs",
  "percent-encoding",
@@ -5470,7 +5495,7 @@ checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types 0.5.0",
  "js-sys",
  "log",
@@ -5885,7 +5910,7 @@ checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,9 @@ reqwest_dav = "=0.2.1"
 tauri-plugin-process = "=2.0.0"
 jieba-rs = { version = "0.7", features = ["textrank"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-graphics = "0.23"
+
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.tauri]
 version = "2"
 features = ["tray-icon"]

--- a/src-tauri/src/screenshot.rs
+++ b/src-tauri/src/screenshot.rs
@@ -1,6 +1,9 @@
 use tauri::{path::BaseDirectory, AppHandle, Manager};
 use xcap::{Window};
 
+#[cfg(target_os = "macos")]
+use core_graphics::display::CGDisplay;
+
 #[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone)]
 pub struct ScreenshotImage {
@@ -28,7 +31,12 @@ fn normalized(s: &str) -> String {
 #[allow(dead_code)]
 #[tauri::command]
 pub fn screenshot(app: AppHandle) -> Vec<ScreenshotImage> {
-
+    #[cfg(target_os = "macos")]
+    {
+        let display = CGDisplay::main();
+        let _ = display.image();
+    }
+    
     let windows = Window::all().unwrap();
 
     let temp_screenshot_folder = app

--- a/src/app/core/record/mark/control-scan.tsx
+++ b/src/app/core/record/mark/control-scan.tsx
@@ -70,9 +70,11 @@ export function ControlScan() {
       }
     })
     setFiles(convertedFiles)
-    const image = new window.Image();
-    image.src = convertedFiles[0].path;
-    setImage(image)
+    if (convertedFiles.length > 0) {
+      const image = new window.Image();
+      image.src = convertedFiles[0].path;
+      setImage(image)
+    }
   }
 
   function selectImage(file: ScreenshotImage) {


### PR DESCRIPTION
- 使用core-graphics库的CGDisplay API触发macOS权限请求对话框
- 修复空数组访问导致的undefined错误