### PR TITLE
fix: #488 修复查看目录功能失败问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@tauri-apps/plugin-fs": "~2",
     "@tauri-apps/plugin-global-shortcut": "~2.2.0",
     "@tauri-apps/plugin-http": "~2.3.0",
+    "@tauri-apps/plugin-opener": "^2.4.0",
     "@tauri-apps/plugin-os": "~2.2.1",
     "@tauri-apps/plugin-process": "~2.2.1",
     "@tauri-apps/plugin-shell": "~2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@tauri-apps/plugin-http':
         specifier: ~2.3.0
         version: 2.3.0
+      '@tauri-apps/plugin-opener':
+        specifier: ^2.4.0
+        version: 2.4.0
       '@tauri-apps/plugin-os':
         specifier: ~2.2.1
         version: 2.2.2
@@ -1606,6 +1609,9 @@ packages:
 
   '@tauri-apps/plugin-http@2.3.0':
     resolution: {integrity: sha512-pigTvz+zzAqbIhCzRiR1GE98Jw7A03j2V+Eiexr9thBI8VfMiwFQMcbgON51xlwnVaI72LdbYKNajU84im8tlg==}
+
+  '@tauri-apps/plugin-opener@2.4.0':
+    resolution: {integrity: sha512-43VyN8JJtvKWJY72WI/KNZszTpDpzHULFxQs0CJBIYUdCRowQ6Q1feWTDb979N7nldqSuDOaBupZ6wz2nvuWwQ==}
 
   '@tauri-apps/plugin-os@2.2.2':
     resolution: {integrity: sha512-pZ03bQeRTgid5u5F5nVLhJ6+nS4caAZggwaeZMsChuFvV2SV+EEJkf4XhH1L5fsRnEKlNoyHO5oA5viAy7RtNw==}
@@ -5002,6 +5008,10 @@ snapshots:
       '@tauri-apps/api': 2.6.0
 
   '@tauri-apps/plugin-http@2.3.0':
+    dependencies:
+      '@tauri-apps/api': 2.6.0
+
+  '@tauri-apps/plugin-opener@2.4.0':
     dependencies:
       '@tauri-apps/api': 2.6.0
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3381,6 +3381,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-http",
+ "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-shell",
@@ -6166,6 +6167,28 @@ dependencies = [
  "tokio",
  "url",
  "urlpattern",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecee219f11cdac713ab32959db5d0cceec4810ba4f4458da992292ecf9660321"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation 0.3.1",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
+ "url",
+ "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ urlencoding = "2.1.3"
 percent-encoding = "2.3.0"
 fuzzy-matcher = "0.3.7"
 rayon = "1.8.0"
+tauri-plugin-opener = "2.4.0"
 
 [dependencies.tauri-plugin-sql]
 features = ["sqlite"]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -114,6 +114,14 @@
     },
     "os:default",
     "dialog:default",
-    "http:default"
+    "http:default",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        {
+          "path": "**"
+        }
+      ]
+    }
   ]
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,7 @@ fn main() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_opener::init())
         .setup(|app| {
             let _tray = TrayIconBuilder::new()
                 .icon(app.default_window_icon().unwrap().clone())

--- a/src/app/core/article/file/file-item.tsx
+++ b/src/app/core/article/file/file-item.tsx
@@ -8,7 +8,7 @@ import { ask } from '@tauri-apps/plugin-dialog';
 import { Store } from '@tauri-apps/plugin-store';
 import { RepoNames } from "@/lib/github.types";
 import { cloneDeep } from "lodash-es";
-import { open } from "@tauri-apps/plugin-shell";
+import { openPath } from "@tauri-apps/plugin-opener";
 import { computedParentPath, getCurrentFolder } from "@/lib/path";
 import { toast } from "@/hooks/use-toast";
 import { useTranslations } from "next-intl";
@@ -290,11 +290,11 @@ export function FileItem({ item }: { item: DirTree }) {
     if (workspace.isCustom) {
       // 自定义工作区 - 直接使用工作区路径
       const pathOptions = await getFilePathOptions(folderPath)
-      open(pathOptions.path)
+      openPath(pathOptions.path)
     } else {
       // 默认工作区 - 使用 AppData 目录
       const appDir = await appDataDir()
-      open(await join(appDir, 'article', folderPath))
+      openPath(await join(appDir, 'article', folderPath))
     }
   }
 

--- a/src/app/core/article/file/folder-item/view-directory.tsx
+++ b/src/app/core/article/file/folder-item/view-directory.tsx
@@ -3,7 +3,7 @@ import { DirTree } from "@/stores/article";
 import { useTranslations } from "next-intl";
 import { computedParentPath } from "@/lib/path";
 import { appDataDir } from '@tauri-apps/api/path';
-import { open } from "@tauri-apps/plugin-shell";
+import { openPath } from "@tauri-apps/plugin-opener";
 
 interface ViewDirectoryProps {
   item: DirTree;
@@ -22,11 +22,11 @@ export function ViewDirectory({ item }: ViewDirectoryProps) {
     if (workspace.isCustom) {
       // 自定义工作区 - 直接使用工作区路径
       const pathOptions = await getFilePathOptions(path);
-      open(pathOptions.path);
+      openPath(pathOptions.path);
     } else {
       // 默认工作区 - 使用 AppData 目录
       const appDir = await appDataDir();
-      open(`${appDir}/article/${path}`);
+      openPath(`${appDir}/article/${path}`);
     }
   }
 


### PR DESCRIPTION
原因：Tauri 2.0 shell插件不支持打开本地路径
解决：迁移到opener插件，使用openPath替代open
- 添加tauri-plugin-opener依赖
- 更新view-directory.tsx和file-item.tsx
- 配置opener权限允许打开本地路径

参考URL:
- https://v2.tauri.app/reference/javascript/shell/
- https://github.com/tauri-apps/plugins-workspace/security/advisories/GHSA-c9pr-q8gx-3mgp