### PR TITLE
fix(codexu#207, codexu#310): 修复 WebDAV 坚果云及自建 优化双栈ipv6加防抖深度自检

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -250,7 +250,7 @@
         "backupTo": "Backup to WebDAV",
         "syncFrom": "Sync from WebDAV",
         "serverUrl": "WebDAV Server URL",
-        "serverUrlDesc": "Enter the URL of the WebDAV server, e.g: https://dav.example.com",
+        "serverUrlDesc": "Enter the URL of the WebDAV server No path included, e.g: https://dav.example.com http://192.8.8.88:9999",
         "serverUrlPlaceholder": "https://dav.example.com",
         "username": "Username",
         "usernameDesc": "WebDAV server username",
@@ -264,7 +264,19 @@
         "backupSuccess": "Backup Successful",
         "backupSuccessDesc": "Backed up {count} files to WebDAV.",
         "syncSuccess": "Sync Successful",
-        "syncSuccessDesc": "Synced {count} files from WebDAV to local."
+        "syncSuccessDesc": "Synced {count} files from WebDAV to local.",
+        "syncFailed": "Sync Failed",
+        "backupFailed": "Backup Failed",
+        "directoryCreated": "Directory Created",
+        "directoryCreatedDesc": "Directory {path} created successfully.",
+        "createDir": "Create Directory",
+        "success": "Success",
+        "failed": "Failed",
+        "error": {
+          "pathNotFound": "Path not found or server inaccessible.",
+          "createDirFailed": "Failed to create directory",
+          "connectionTimeOut": "Connection timed out, please check network or server."
+        }
       }
     },
     "template": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -248,7 +248,7 @@
         "backupTo": "WebDAVにバックアップ",
         "syncFrom": "WebDAVから同期",
         "serverUrl": "WebDAVサーバーURL",
-        "serverUrlDesc": "WebDAVサーバーのURLを入力してください、例：https://dav.example.com",
+        "serverUrlDesc": "WebDAVサーバーのURLを入力してくださいパスを含まない、例：https://dav.example.com http://192.8.8.88:9999 ",
         "serverUrlPlaceholder": "https://dav.example.com",
         "username": "ユーザー名",
         "usernameDesc": "WebDAVサーバーのユーザー名",
@@ -262,7 +262,19 @@
         "backupSuccess": "バックアップ成功",
         "backupSuccessDesc": "{count} 個のファイルをWebDAVにバックアップしました。",
         "syncSuccess": "同期成功",
-        "syncSuccessDesc": "WebDAVからローカルに {count} 個のファイルを同期しました。"
+        "syncSuccessDesc": "WebDAVからローカルに {count} 個のファイルを同期しました。",
+        "syncFailed": "同期失敗",
+        "backupFailed": "バックアップ失敗",
+        "directoryCreated": "ディレクトリが作成されました",
+        "directoryCreatedDesc": "ディレクトリ {path} が正常に作成されました。",
+        "createDir": "ディレクトリを作成",
+        "success": "成功",
+        "failed": "失敗",
+        "error": {
+          "pathNotFound": "パスが存在しないか、サーバーにアクセスできません。",
+          "createDirFailed": "ディレクトリの作成に失敗しました",
+          "connectionTimeOut": "接続タイムアウト、ネットワークまたはサーバーを確認してください。"
+        }
       }
     },
     "template": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -232,7 +232,7 @@
         "backupTo": "备份至 WebDAV",
         "syncFrom": "从 WebDAV 同步",
         "serverUrl": "WebDAV 服务器地址",
-        "serverUrlDesc": "输入WebDAV服务器的URL，例如：https://dav.example.com",
+        "serverUrlDesc": "输入WebDAV服务器的URL不含路径，例如：https://dav.example.com http://192.8.8.88:9999 ",
         "serverUrlPlaceholder": "https://dav.example.com",
         "username": "用户名",
         "usernameDesc": "WebDAV服务器的用户名",
@@ -246,7 +246,19 @@
         "backupSuccess": "备份成功",
         "backupSuccessDesc": "已备份 {count} 个文件至 WebDAV。",
         "syncSuccess": "同步成功",
-        "syncSuccessDesc": "已从 WebDAV 同步至本地 {count} 个文件。"
+        "syncSuccessDesc": "已从 WebDAV 同步至本地 {count} 个文件。",
+        "syncFailed": "同步失败",
+        "backupFailed": "备份失败",
+        "directoryCreated": "目录已创建",
+        "directoryCreatedDesc": "目录 {path} 已成功创建。",
+        "createDir": "创建目录",
+        "success": "成功",
+        "failed": "失败",
+        "error": {
+          "pathNotFound": "路径不存在或服务器无法访问。",
+          "createDirFailed": "创建目录失败",
+          "connectionTimeOut": "连接超时，请检查网络或服务器。"
+        }
       }
     },
     "template": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3389,6 +3389,8 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tokio",
+ "url",
  "urlencoding",
  "xcap",
 ]
@@ -6563,6 +6565,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,8 @@ urlencoding = "2.1.3"
 percent-encoding = "2.3.0"
 fuzzy-matcher = "0.3.7"
 rayon = "1.8.0"
+tokio = { version = "1", features = ["full"] } 
+url = "2.5"
 
 [dependencies.tauri-plugin-sql]
 features = ["sqlite"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ fuzzy-matcher = "0.3.7"
 rayon = "1.8.0"
 tokio = { version = "1", features = ["full"] } 
 url = "2.5"
+reqwest_dav = "=0.2.1"
 
 [dependencies.tauri-plugin-sql]
 features = ["sqlite"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,5 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
+mod webdav;
+use webdav::{webdav_backup, webdav_create_dir, webdav_sync, webdav_test};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -14,7 +11,12 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_sql::Builder::default().build())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![
+            webdav_test,
+            webdav_backup,
+            webdav_sync,
+            webdav_create_dir,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,7 +9,7 @@ use tauri::{
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
     Manager,
 };
-use webdav::{webdav_backup, webdav_sync, webdav_test};
+use webdav::{webdav_backup, webdav_sync, webdav_test, webdav_create_dir};
 use fuzzy_search::{fuzzy_search, fuzzy_search_parallel};
 use keywords::{rank_keywords};
 
@@ -88,6 +88,7 @@ fn main() {
             fuzzy_search,
             fuzzy_search_parallel,
             rank_keywords,
+            webdav_create_dir,
         ])
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_store::Builder::new().build())

--- a/src-tauri/src/webdav.rs
+++ b/src-tauri/src/webdav.rs
@@ -4,20 +4,105 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 
-fn create_client(url: &str, username: &str, password: &str) -> Result<Client, String> {
-    let host_url = if url.ends_with('/') {
-        url.to_string()
-    } else {
-        format!("{}/", url)
-    };
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
+use tokio::net::lookup_host;
+use tokio::net::TcpStream;
+use tokio::time::{timeout, Duration};
+use url::Url;
 
+//全局变量
+static WEBDAV_DEPTH_STRATEGY: AtomicU32 = AtomicU32::new(1);
+
+//超时控制
+async fn test_depth_with_timeout(
+    client: &Client,
+    path: &str,
+    depth: Depth,
+    timeout_secs: u64,
+) -> bool {
+    timeout(Duration::from_secs(timeout_secs), client.list(path, depth))
+        .await
+        .map(|result| result.is_ok())
+        .unwrap_or(false)
+}
+
+
+// WebDAV客户端创建：建立连接并验证服务器可达性
+pub async fn create_client(url: &str, username: &str, password: &str) -> Result<Client, String> {
+    
+    // 超时时间
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(6);
+
+    // URL解析
+    let parsed_url = Url::parse(url).map_err(|e| format!("URL 解析失败: {}", e))?;
+
+    // 核心逻辑：根据 Scheme 决定连接策略
+    if parsed_url.scheme() == "https" {
+      
+        // 1. 创建带超时的 reqwest 客户端
+        let http_client = reqwest_dav::re_exports::reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(Duration::from_secs(30)) // 为整个请求设置一个更长的超时
+            .build()
+            .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))?;
+
+        // 2. 将原始 URL 和配置好的客户端传递给 ClientBuilder
+        ClientBuilder::new()
+            .set_host(url.to_string()) // 直接使用原始 URL
+            .set_auth(Auth::Basic(username.to_owned(), password.to_owned()))
+            .set_agent(http_client) // 使用 set_agent 注入配置
+            .build()
+            .map_err(|e| format!("创建 WebDAV 客户端失败: {}", e))
+
+    } else {
+        // --- HTTP 策略继续使用 IP 直连可以避免一些 DNS 问题
+
+        let host = parsed_url
+            .host_str()
+            .ok_or_else(|| "URL 中未找到主机名".to_string())?;
+        let port = parsed_url
+            .port_or_known_default()
+            .ok_or_else(|| "URL 中缺少有效的端口".to_string())?;
+
+        // DNS解析获取IP地址
+        let dns_lookup_future = lookup_host(format!("{}:{}", host, port));
+        let addrs: Vec<SocketAddr> = match timeout(CONNECT_TIMEOUT, dns_lookup_future).await {
+            Ok(Ok(addrs)) => addrs.collect(),
+            Ok(Err(e)) => return Err(format!("DNS 解析失败: {}", e)),
+            Err(_) => return Err(format!("DNS 解析超时 ({} 秒)", CONNECT_TIMEOUT.as_secs())),
+        };
+
+        if addrs.is_empty() {
+            return Err(format!("DNS 解析未返回任何 IP 地址 for {}", host));
+        }
+        let final_ip_addr = addrs
+            .iter()
+            .find(|addr| addr.is_ipv6())
+            .unwrap_or(&addrs[0]);
+
+        // TCP连接测试
+        let preflight_future = TcpStream::connect(final_ip_addr);
+        match timeout(CONNECT_TIMEOUT, preflight_future).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => return Err(format!("服务器连接被拒绝: {}", e)),
+            Err(_) => return Err(format!("服务器连接超时 ({} 秒)", CONNECT_TIMEOUT.as_secs())),
+        }
+
+        // WebDAV客户端构建
+        let host_url = format!("{}://{}/", parsed_url.scheme(), final_ip_addr);
     ClientBuilder::new()
         .set_host(host_url)
         .set_auth(Auth::Basic(username.to_owned(), password.to_owned()))
         .build()
-        .map_err(|e| format!("Failed to create WebDAV client: {}", e))
+            .map_err(|e| format!("创建 WebDAV 客户端失败: {}", e))
+    }
 }
 
+
+
+// WebDAV连接测试：验证连接并检测服务器深度支持
 #[tauri::command]
 pub async fn webdav_test(
     url: String,
@@ -25,36 +110,251 @@ pub async fn webdav_test(
     password: String,
     path: String,
 ) -> Result<bool, String> {
-    let client = match create_client(&url, &username, &password) {
-        Ok(client) => client,
-        Err(e) => return Err(e),
-    };
+    let client = create_client(&url, &username, &password).await?;
+    let test_path = normalize_path(&path, true);
 
-    let test_path = if path.starts_with('/') {
-        path[1..].to_string()
-    } else {
-        path
-    };
+    // 优先尝试 Depth::Infinity
+    if test_depth_with_timeout(&client, &test_path, Depth::Infinity, 2).await {
+        println!("Server supports Depth::Infinity. Setting global strategy to 0.");
+        WEBDAV_DEPTH_STRATEGY.store(0, Ordering::SeqCst);
+        return Ok(true);
+    }
 
-    match client.list(&test_path, Depth::Infinity).await {
-        Ok(_) => Ok(true),
+    // 降级尝试 Depth::Number(1)
+    if test_depth_with_timeout(&client, &test_path, Depth::Number(1), 2).await {
+        println!("Server supports Depth::1. Setting global strategy to 1.");
+        WEBDAV_DEPTH_STRATEGY.store(1, Ordering::SeqCst);
+        return Ok(true);
+    }
+
+    // 深度检测失败返回连接错误
+    Err(format!(
+        "[ERR_PATH_NOT_FOUND] Path may not exist or credentials are wrong"
+    ))
+}
+
+//WebDAV 备份命令
+#[tauri::command]
+pub async fn webdav_backup(
+    url: String,
+    username: String,
+    password: String,
+    path: String,
+    app: AppHandle,
+) -> Result<String, String> {
+    // 客户端初始化
+    let client = create_client(&url, &username, &password).await?; 
+    let webdav_path = normalize_path(&path, true);
+
+    // 在准备上传文件前，确保根备份目录存在
+   if !webdav_path.is_empty() {
+        if let Err(e) = ensure_path_exists_recursively(&client, &webdav_path).await {
+            return Err(format!("创建远程根目录失败: {}", e));
+        }
+    }
+
+    // 获取本地工作区信息和文件列表
+    let (workspace_dir, is_custom_workspace) = get_workspace_info(&app).await?;
+    let markdown_files = get_markdown_files(&workspace_dir, is_custom_workspace, &app).await?;
+    let total_files = markdown_files.len();
+    let mut success_count = 0;
+    
+    // 批量上传文件到远程服务器
+   for (relative_path, content) in markdown_files {
+        let remote_path = build_remote_path(&webdav_path, &relative_path);
+
+
+        // 确保文件自身的父目录存在
+        if let Some(parent) = get_parent_path(&remote_path) {
+            
+            if let Err(e) = ensure_path_exists_recursively(&client, &parent).await {
+                return Err(format!("为文件 {} 创建父目录失败: {}", remote_path, e));
+            }
+        }
+
+        // 上传文件
+        let content_bytes = content.as_bytes().to_vec();
+        match client.put(&remote_path, content_bytes).await {
+            Ok(_) => success_count += 1,
+            Err(e) => return Err(format!("上传文件 {} 失败: {}", relative_path, e)),
+        }
+    }
+
+
+    Ok(format!("{}/{}", success_count, total_files))
+}
+
+// WebDAV 同步命令
+#[tauri::command]
+pub async fn webdav_sync(
+    url: String,
+    username: String,
+    password: String,
+    path: String,
+    app: AppHandle,
+) -> Result<String, String> {
+    // 客户端初始化
+    let client = create_client(&url, &username, &password).await?; 
+    let webdav_path = normalize_path(&path, true);
+
+    // 远程路径存在性检查
+    let entries = match client.list(&webdav_path, Depth::Number(1)).await {
+        Ok(entries) => entries,
         Err(e) => {
-            // 如果不存在目录则创建
-            if let Err(create_err) = client.mkcol(&test_path).await {
-                return Err(format!(
-                    "Connection failed: {}, couldn't create directory: {}",
-                    e, create_err
-                ));
+            let error_string = e.to_string();
+            if error_string.contains("NotFound") {
+                return Err(format!("[ERR_PATH_NOT_FOUND] {}", path));
+            } else {
+                return Err(format!("Failed to list WebDAV directory: {}", error_string));
             }
+        }
+    };
 
-            match client.list(&test_path, Depth::Infinity).await {
-                Ok(_) => Ok(true),
-                Err(e) => Err(format!("Connection failed: {}", e)),
+    // 本地工作区信息获取
+    let (workspace_dir, _is_custom_workspace) = get_workspace_info(&app).await?;
+    let base_workspace_path = PathBuf::from(workspace_dir);
+
+    // 远程文件列表获取
+    let markdown_files = get_webdav_markdown_files(entries, &webdav_path, &client).await?;
+    let total_files = markdown_files.len();
+
+    if total_files == 0 {
+        return Ok("0/0".to_string());
+    }
+
+    //批量下载并保存文件
+    let mut success_count = 0;
+    
+    for (remote_path, relative_path) in markdown_files {
+        // 下载路径处理
+        let prefix = extract_prefix(&remote_path, &webdav_path);
+        let path_for_request = remote_path.trim_start_matches(&prefix);
+
+        // 文件内容下载
+        let bytes = match client.get(path_for_request).await {
+            Ok(response) => {
+                match response.bytes().await {
+                    Ok(bytes) => bytes.to_vec(),
+                    Err(e) => {
+                        eprintln!("读取响应体失败 {}: {}", remote_path, e);
+                        continue;
+                    }
+                }
             }
+            Err(e) => {
+                eprintln!("下载文件失败 {}: {}", remote_path, e);
+                continue;
+            }
+        };
+
+        // 本地保存路径处理
+        let local_file_path = match process_local_path(&relative_path, &base_workspace_path) {
+            Ok(path) => path,
+        Err(e) => {
+                eprintln!("路径处理失败 {}: {}", relative_path, e);
+                continue;
+            }
+        };
+
+        // 文件写入本地磁盘
+        if save_file_to_disk(&local_file_path, &bytes).is_ok() {
+            success_count += 1;
+        }
+    }
+
+    Ok(format!("{}/{}", success_count, total_files))
+}
+
+//处理本地保存路径
+fn process_local_path(
+    relative_path: &str,
+    base_workspace_path: &PathBuf,
+) -> Result<PathBuf, String> {
+    // URL 解码
+    let decoded_relative_path = percent_decode_str(relative_path)
+        .decode_utf8()
+        .unwrap_or_else(|_| relative_path.into())
+        .to_string();
+
+    let relative_path_obj = Path::new(&decoded_relative_path);
+
+    // 安全检查：拒绝绝对路径
+    if relative_path_obj.is_absolute() {
+        return Err(format!("安全警告：检测到绝对路径 '{}' 已跳过", decoded_relative_path));
+    }
+
+    // 规范化路径
+    let sanitized_path: PathBuf = relative_path_obj.components().collect();
+    let local_file_path = base_workspace_path.join(sanitized_path);
+
+    // 防止路径逃逸
+    if !local_file_path.starts_with(base_workspace_path) {
+        return Err(format!("安全警告：路径逃逸 '{}' 已跳过", local_file_path.display()));
+    }
+
+    Ok(local_file_path)
+}
+
+// 保存文件到磁盘
+fn save_file_to_disk(local_file_path: &PathBuf, bytes: &[u8]) -> Result<(), String> {
+    // 确保父目录存在
+    if let Some(parent) = local_file_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("创建本地目录失败: {}", e))?;
+        }
+    }
+
+    // 写入文件
+    fs::write(local_file_path, bytes)
+        .map_err(|e| {
+            eprintln!("写入文件失败 {}: {}", local_file_path.display(), e);
+            format!("写入文件失败: {}", e)
+        })
+}
+
+
+// WebDAV 创建目录
+#[tauri::command]
+pub async fn webdav_create_dir(
+    url: String,
+    username: String,
+    password: String,
+    path: String,
+) -> Result<(), String> {
+    let client = create_client(&url, &username, &password).await?;
+    let parts: Vec<&str> = path.trim().split('/').filter(|s| !s.is_empty()).collect();
+    if parts.is_empty() {
+        return Ok(());
+    }
+    let mut current_path = String::new();
+
+    //逐个创建路径中的目录
+    for part in parts {
+        current_path.push_str(part);
+        let path_for_request = format!("{}/", current_path);
+
+        match client.list(&path_for_request, Depth::Number(0)).await {
+            Ok(_) => {
+                // 目录已存在，在 current_path 后加上斜杠，为下一轮循环做准备
+                current_path.push('/');
+                continue;
+            }
+            Err(_) => {
+                // 目录不存在尝试创建
+                if let Err(e) = client.mkcol(&path_for_request).await {
+                    return Err(format!("创建目录 '{}' 失败: {}", path_for_request, e));
+                }
+                current_path.push('/');
         }
     }
 }
 
+    Ok(())
+}
+
+
+//辅助函数：获取本地 Markdown文件
 async fn get_markdown_files(
     dir_path: &str,
     is_custom_workspace: bool,
@@ -133,139 +433,7 @@ async fn _get_markdown_files(
     Ok(markdown_files)
 }
 
-// 获取工作区路径信息
-async fn get_workspace_info(app: &AppHandle) -> Result<(String, bool), String> {
-    let store_path = app
-        .path()
-        .app_config_dir()
-        .map_err(|e| format!("Failed to get config dir: {}", e))?
-        .join("store.json");
-
-    let store_contents =
-        fs::read_to_string(&store_path).map_err(|e| format!("Failed to read store file: {}", e))?;
-
-    let store_json: serde_json::Value = serde_json::from_str(&store_contents)
-        .map_err(|e| format!("Failed to parse store JSON: {}", e))?;
-
-    let store_workspace_path = store_json
-        .get("workspacePath")
-        .and_then(|v| v.as_str())
-        .unwrap_or("article");
-
-    let workspace_path = if store_workspace_path.is_empty() {
-        ("article".to_string(), false)
-    } else {
-        (store_workspace_path.to_string(), true)
-    };
-
-    Ok(workspace_path)
-}
-
-// 获取本地文件路径
-fn get_local_file_path(
-    relative_path: &str,
-    workspace_path: &str,
-    is_custom_workspace: bool,
-    app: &AppHandle,
-) -> Result<PathBuf, String> {
-    if is_custom_workspace {
-        Ok(PathBuf::from(workspace_path).join(relative_path))
-    } else {
-        let app_data_dir = app
-            .path()
-            .app_data_dir()
-            .map_err(|e| format!("Failed to get app data dir: {}", e))?;
-        Ok(app_data_dir.join(workspace_path).join(relative_path))
-    }
-}
-
-// 确保目录存在
-fn ensure_directory_exists(dir_path: &Path) -> Result<(), String> {
-    if !dir_path.exists() {
-        fs::create_dir_all(dir_path)
-            .map_err(|e| format!("Failed to create directory {}: {}", dir_path.display(), e))?
-    }
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn webdav_backup(
-    url: String,
-    username: String,
-    password: String,
-    path: String,
-    app: AppHandle,
-) -> Result<String, String> {
-    let client = match create_client(&url, &username, &password) {
-        Ok(client) => client,
-        Err(e) => return Err(e),
-    };
-
-    let webdav_path = if path.starts_with('/') {
-        path[1..].to_string()
-    } else {
-        path.clone()
-    };
-
-    if let Err(_) = client.list(&webdav_path, Depth::Infinity).await {
-        if let Err(e) = client.mkcol(&webdav_path).await {
-            return Err(format!(
-                "Failed to create directory on WebDAV server: {}",
-                e
-            ));
-        }
-    }
-
-    let workspace_path = get_workspace_info(&app).await?;
-    let markdown_files = get_markdown_files(&workspace_path.0, workspace_path.1, &app).await?;
-
-    let mut success_count = 0;
-    let total_files = markdown_files.len();
-
-    for (relative_path, content) in markdown_files {
-        let remote_path = format!("{}/{}", webdav_path.trim_end_matches('/'), relative_path);
-
-        if let Some(parent) = Path::new(&remote_path).parent() {
-            let parent_str = parent.to_string_lossy().to_string();
-            if !parent_str.is_empty() && parent_str != "." {
-                if let Err(_) = client.list(&parent_str, Depth::Infinity).await {
-                    if let Err(e) = client.mkcol(&parent_str).await {
-                        return Err(format!(
-                            "Failed to create directory {} on WebDAV server: {}",
-                            parent_str, e
-                        ));
-                    }
-                }
-            }
-        }
-
-        let content_bytes = content.as_bytes().to_vec();
-        if let Err(e) = client.put(&remote_path, content_bytes).await {
-            return Err(format!(
-                "Failed to upload file {} to WebDAV server: {}",
-                relative_path, e
-            ));
-        }
-
-        success_count += 1;
-    }
-
-    Ok(format!("{}/{}", success_count, total_files))
-}
-
-fn extract_prefix(remote_path: &str, webdav_path: &str) -> String {
-    // 确保 webdav_path 不以 '/' 开头，因为我们想匹配中间部分
-    let webdav_path_trimmed = webdav_path.trim_start_matches('/');
-
-    // 查找 webdav_path 在 remote_path 中的位置
-    if let Some(pos) = remote_path.find(webdav_path_trimmed) {
-        // 提取前缀部分
-        remote_path[..pos].to_string()
-    } else {
-        "".to_string()
-    }
-}
-
+//辅助函数：获取远程 Markdown文件
 async fn get_webdav_markdown_files(
     entries: Vec<ListEntity>,
     webdav_path: &str,
@@ -274,7 +442,7 @@ async fn get_webdav_markdown_files(
     let mut markdown_files: Vec<(String, String)> = Vec::new();
 
     // 遍历所有条目并提取Markdown文件路径
-    for entry in entries {
+    for entry in &entries.clone() {
         // 使用序列化格式提取路径
         let entry_json = serde_json::to_value(entry).unwrap_or(serde_json::Value::Null);
 
@@ -329,9 +497,23 @@ async fn get_webdav_markdown_files(
                 let prefix = extract_prefix(&folder_path, webdav_path);
                 let path_for_request = folder_path.trim_start_matches(&prefix);
                 // 递归获取子目录中的Markdown文件
-                let entries = match client.list(&path_for_request, Depth::Infinity).await {
+                let strategy_value = WEBDAV_DEPTH_STRATEGY.load(Ordering::SeqCst);
+                let sub_entries = if strategy_value == 0 {
+                    match client.list(&path_for_request, Depth::Infinity).await {
                     Ok(entries) => entries,
-                    Err(e) => return Err(format!("Failed to list WebDAV directory: {}", e)),
+                        Err(e) => {
+                            eprintln!("Failed to list directory {}: {}", path_for_request, e);
+                            continue; // 跳过这个目录，不中断整个过程
+                        }
+                    }
+                } else {
+                    match client.list(&path_for_request, Depth::Number(1)).await {
+                        Ok(entries) => entries,
+                        Err(e) => {
+                            eprintln!("Failed to list directory {}: {}", path_for_request, e);
+                            continue;
+                        }
+                    }
                 };
 
                 // 如果 folder_path == prefix + webdav_path，说明是根目录，不进入循环
@@ -342,7 +524,7 @@ async fn get_webdav_markdown_files(
 
                 // Use Box::pin to handle recursive async call
                 let sub_markdown_files = Box::pin(get_webdav_markdown_files(
-                    entries,
+                    sub_entries,
                     &path_for_request,
                     client,
                 ))
@@ -359,92 +541,126 @@ async fn get_webdav_markdown_files(
     Ok(markdown_files)
 }
 
-#[tauri::command]
-pub async fn webdav_sync(
-    url: String,
-    username: String,
-    password: String,
-    path: String,
-    app: AppHandle,
-) -> Result<String, String> {
-    // 创建WebDAV客户端
-    let client = match create_client(&url, &username, &password) {
-        Ok(client) => client,
-        Err(e) => return Err(e),
-    };
+// 辅助函数：获取工作区路径信息
+async fn get_workspace_info(app: &AppHandle) -> Result<(String, bool), String> {
+   let store_path = app
+       .path()
+       .app_config_dir()
+       .map_err(|e| format!("Failed to get config dir: {}", e))?
+       .join("store.json");
 
-    // 处理WebDAV路径
-    let webdav_path = if path.starts_with('/') {
-        path[1..].to_string()
+   let store_contents =
+       fs::read_to_string(&store_path).map_err(|e| format!("Failed to read store file: {}", e))?;
+
+   let store_json: serde_json::Value = serde_json::from_str(&store_contents)
+       .map_err(|e| format!("Failed to parse store JSON: {}", e))?;
+
+   let store_workspace_path = store_json
+       .get("workspacePath")
+       .and_then(|v| v.as_str())
+       .unwrap_or("article");
+
+   let workspace_path = if store_workspace_path.is_empty() || store_workspace_path == "article" {
+       // 默认工作区：使用应用数据目录
+       let app_data_dir = app
+           .path()
+           .app_data_dir()
+           .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+       let default_path = app_data_dir.join("article");
+       (default_path.to_string_lossy().to_string(), false)
     } else {
-        path.clone()
+       // 自定义工作区：使用用户指定路径
+       (store_workspace_path.to_string(), true)
     };
 
-    // 检查WebDAV路径是否存在
-    let entries = match client.list(&webdav_path, Depth::Infinity).await {
-        Ok(entries) => entries,
-        Err(e) => return Err(format!("Failed to list WebDAV directory: {}", e)),
+   Ok(workspace_path)
+}
+
+// 辅助函数：确保远程目录存在
+async fn ensure_path_exists_recursively(client: &Client, path: &str) -> Result<(), String> {
+    // 处理空路径情况
+    if path.trim().is_empty() {
+        // 空路径检查根目录是否可访问
+        return match client.list("", Depth::Number(0)).await {
+            Ok(_) => Ok(()),
+            Err(e) => Err(format!("根目录不可访问: {}", e)),
     };
-
-    // 获取工作区路径信息
-    let (workspace_dir, is_custom_workspace) = get_workspace_info(&app).await?;
-
-    let mut success_count = 0;
-    let markdown_files = get_webdav_markdown_files(entries, &webdav_path, &client).await?;
-
-    let total_files = markdown_files.len();
-
-    // 下载并保存文件
-    for (remote_path, relative_path) in markdown_files {
-        // 从完整路径中提取相对路径，去除URL前缀
-        // 通过 remote_path 获取到 webdav_path 前的字符串
-        let prefix = extract_prefix(&remote_path, &webdav_path);
-        // 移除 remote_path 的 prefix 部分
-        let path_for_request = remote_path.trim_start_matches(&prefix);
-
-        // 获取文件内容 - 使用 path_for_request 而不是完整的URL路径
-        let response = match client.get(path_for_request).await {
-            Ok(response) => response,
-            Err(e) => {
-                eprintln!("Failed to download file {}: {}", remote_path, e);
-                continue;
-            }
-        };
-
-        // 获取响应体内容
-        let bytes = match response.bytes().await {
-            Ok(bytes) => bytes.to_vec(),
-            Err(e) => {
-                eprintln!("Failed to read response body for {}: {}", remote_path, e);
-                continue;
-            }
-        };
-
-        let output_path = relative_path
-            .trim_start_matches(&prefix.trim_start_matches('/'))
-            .trim_start_matches(&webdav_path);
-
-        // URL解码路径，确保中文字符正确处理
-        let decoded_path = percent_decode_str(output_path)
-            .decode_utf8()
-            .unwrap_or_else(|_| output_path.into())
-            .to_string();
-
-        // 确定本地文件路径
-        let local_file_path =
-            get_local_file_path(&decoded_path, &workspace_dir, is_custom_workspace, &app)?;
-
-        // 确保父目录存在
-        if let Some(parent) = local_file_path.parent() {
-            ensure_directory_exists(parent)?;
-        }
-
-        // 写入文件
-        match fs::write(&local_file_path, &bytes) {
-            Ok(_) => success_count += 1,
-            Err(e) => eprintln!("Failed to write file {}: {}", local_file_path.display(), e),
-        };
     }
 
-    Ok(format!("{}/{}", success_count, total_files))
+    // 处理非空路径
+    let parts: Vec<&str> = path
+        .trim_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let mut current_path = String::new();
+
+    for part in parts {
+        if !current_path.is_empty() {
+            current_path.push('/');
+        }
+        current_path.push_str(part);
+
+        // 检查目录是否存在
+        match client.list(&current_path, Depth::Number(0)).await {
+            Ok(_) => continue,
+            Err(_) => {
+                // 创建目录
+                if let Err(e) = client.mkcol(&format!("{}/", current_path)).await {
+                    return Err(format!("创建目录 '{}' 失败: {}", current_path, e));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// 辅助函数：规范化文件路径
+fn normalize_path(path: &str, remove_leading_slash: bool) -> String {
+    if path.trim().is_empty() {
+        return String::new();
+            }
+
+    let mut normalized = path.trim().replace('\\', "/");
+    if remove_leading_slash {
+        normalized = normalized.trim_start_matches('/').to_string();
+    }
+    normalized
+}
+
+// 辅助函数：获取父路径
+fn get_parent_path(path: &str) -> Option<String> {
+    let normalized = normalize_path(path,false);
+    if let Some(last_slash) = normalized.rfind('/') {
+        if last_slash == 0 {
+            return None; // 根目录
+        }
+        Some(normalized[..last_slash].to_string())
+    } else {
+        None
+    }
+}
+
+// 辅助函数：远程路径构建
+fn build_remote_path(base_path: &str, relative_path: &str) -> String {
+    if base_path.is_empty() {
+        normalize_path(relative_path, false)
+    } else {
+        format!("{}/{}", base_path.trim_end_matches('/'), normalize_path(relative_path, false))
+    }
+        }
+
+// 辅助函数：提取前缀
+fn extract_prefix(remote_path: &str, webdav_path: &str) -> String {
+    // 确保 webdav_path 不以 '/' 开头，因为我们想匹配中间部分
+    let webdav_path_trimmed = webdav_path.trim_start_matches('/');
+
+    // 查找 webdav_path 在 remote_path 中的位置
+    if let Some(pos) = remote_path.find(webdav_path_trimmed) {
+        // 提取前缀部分
+        remote_path[..pos].to_string()
+    } else {
+        "".to_string()
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,9 +54,6 @@
       ],
       "createUpdaterArtifacts": true,
       "dangerousInsecureTransportProtocol": true
-    },
-    "shell": {
-      "open": "^(https?://|mailto:|tel:|[./]|[A-Za-z]:).*"
     }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,6 +54,9 @@
       ],
       "createUpdaterArtifacts": true,
       "dangerousInsecureTransportProtocol": true
+    },
+    "shell": {
+      "open": "^(https?://|mailto:|tel:|[./]|[A-Za-z]:).*"
     }
   }
 }

--- a/src/stores/webdav.ts
+++ b/src/stores/webdav.ts
@@ -20,7 +20,7 @@ interface WebDAVState {
 
   path: string
   setPath: (path: string) => Promise<void>
-
+  createWebDAVDir: (path: string) => Promise<void>
   connectionState: WebDAVConnectionState
   setConnectionState: (state: WebDAVConnectionState) => void
 
@@ -37,52 +37,39 @@ interface WebDAVState {
   syncFromWebDAV: () => Promise<string>
 }
 
-const useWebDAVStore = create<WebDAVState>((set, get) => ({
-  url: '',
-  setUrl: async (url: string) => {
-    set({ url })
-    const store = await Store.load('store.json')
-    await store.set('webdavUrl', url)
-    get().testConnection()
-  },
+// 防抖函数
+function simpleDebounce<T extends (...args: any[]) => any>(
+  func: T,
+  wait: number
+): (...args: Parameters<T>) => void {
+  let timeout: NodeJS.Timeout | null = null
 
-  username: '',
-  setUsername: async (username: string) => {
-    set({ username })
-    const store = await Store.load('store.json')
-    await store.set('webdavUsername', username)
-    get().testConnection()
-  },
+  return (...args: Parameters<T>) => {
+    if (timeout) clearTimeout(timeout)
+    timeout = setTimeout(() => func(...args), wait)
+  }
+}
 
-  password: '',
-  setPassword: async (password: string) => {
-    set({ password })
-    const store = await Store.load('store.json')
-    await store.set('webdavPassword', password)
-    get().testConnection()
-  },
+const useWebDAVStore = create<WebDAVState>((set, get) => {
+  let isTestingInProgress = false
+  let shouldTestAgain = false
 
-  path: '',
-  setPath: async (path: string) => {
-    set({ path })
-    const store = await Store.load('store.json')
-    await store.set('webdavPath', path)
-    get().testConnection()
-  },
+  const performConnectionTest = async (): Promise<boolean> => {
+    // 防止重复执行
+    if (isTestingInProgress) {
+      shouldTestAgain = true
+      return false
+    }
 
-  connectionState: WebDAVConnectionState.fail,
-  setConnectionState: (connectionState) => {
-    set({ connectionState })
-  },
-
-  testConnection: async () => {
     const { url, username, password, path } = get()
     
-    if (!url || !username || !password) {
+    // 检查配置完整性
+    if (!url?.trim() || !username?.trim() || !password?.trim()) {
       set({ connectionState: WebDAVConnectionState.fail })
       return false
     }
     
+    isTestingInProgress = true
     set({ connectionState: WebDAVConnectionState.checking })
     
     try {
@@ -93,31 +80,104 @@ const useWebDAVStore = create<WebDAVState>((set, get) => ({
         path
       })
       
-      set({ connectionState: result ? WebDAVConnectionState.success : WebDAVConnectionState.fail })
+      set({
+        connectionState: result ? WebDAVConnectionState.success : WebDAVConnectionState.fail
+      })
       return result
-    } catch (error) {
-      console.info('WebDAV connection test failed:', error)
+
+    } catch (_error) {
+      console.error('Failed to test connection:', _error)
       set({ connectionState: WebDAVConnectionState.fail })
       return false
+
+    } finally {
+      isTestingInProgress = false
+
+      // 如果在测试期间有新的测试请求，再次执行
+      if (shouldTestAgain) {
+        shouldTestAgain = false
+        setTimeout(() => performConnectionTest(), 100)
+      }
     }
+  }
+
+  // 使用防抖
+  const debouncedTest = simpleDebounce(performConnectionTest, 300)
+
+  return {
+    url: '',
+    setUrl: async (url: string) => {
+      set({ url })
+      try {
+        const store = await Store.load('store.json')
+        await store.set('webdavUrl', url)
+      } catch (error) {
+        console.error('Failed to save URL:', error)
+      }
+      debouncedTest()
+    },
+
+    username: '',
+    setUsername: async (username: string) => {
+      set({ username })
+      try {
+        const store = await Store.load('store.json')
+        await store.set('webdavUsername', username)
+      } catch (error) {
+        console.error('Failed to save username:', error)
+      }
+      debouncedTest()
+    },
+
+    password: '',
+    setPassword: async (password: string) => {
+      set({ password })
+      try {
+        const store = await Store.load('store.json')
+        await store.set('webdavPassword', password)
+      } catch (error) {
+        console.error('Failed to save password:', error)
+      }
+      debouncedTest()
+    },
+
+    path: '',
+    setPath: async (path: string) => {
+      set({ path })
+      try {
+        const store = await Store.load('store.json')
+        await store.set('webdavPath', path)
+      } catch (error) {
+        console.error('Failed to save path:', error)
+      }
+      debouncedTest()
+    },
+
+    connectionState: WebDAVConnectionState.fail,
+    setConnectionState: (connectionState) => {
+      set({ connectionState })
+    },
+
+    testConnection: async () => {
+      return performConnectionTest()
   },
 
   initWebDAVData: async () => {
+      try {
     const store = await Store.load('store.json')
+        const url = await store.get<string>('webdavUrl') || ''
+        const username = await store.get<string>('webdavUsername') || ''
+        const password = await store.get<string>('webdavPassword') || ''
+        const path = await store.get<string>('webdavPath') || ''
+
+        set({ url, username, password, path })
     
-    const url = await store.get<string>('webdavUrl')
-    if (url) set({ url })
-    
-    const username = await store.get<string>('webdavUsername')
-    if (username) set({ username })
-    
-    const password = await store.get<string>('webdavPassword')
-    if (password) set({ password })
-    
-    const path = await store.get<string>('webdavPath')
-    if (path) set({ path })
-    
-    get().testConnection()
+        if (url && username && password) {
+          setTimeout(() => performConnectionTest(), 100)
+        }
+      } catch (error) {
+        console.error('Failed to load WebDAV data:', error)
+      }
   },
 
   backupState: false,
@@ -130,47 +190,55 @@ const useWebDAVStore = create<WebDAVState>((set, get) => ({
     set({ syncState: state })
   },
 
-  // 备份到WebDAV
   backupToWebDAV: async () => {
-    const { url, username, password, path } = get()
-    get().setBackupState(true)
-    try {
-      const result = await invoke<string>('webdav_backup', {
-        url,
-        username,
-        password,
-        path
-      })
+      const { url, username, password, path, backupState } = get()
 
-      return result
-    } catch (error) {
-      console.error('WebDAV connection test failed:', error)
-      return ''
+      if (backupState) {
+        throw new Error('Backup is already in progress')
+      }
+
+      set({ backupState: true })
+
+    try {
+        return await invoke<string>('webdav_backup', {
+          url, username, password, path
+      })
     } finally {
-      get().setBackupState(false)
+        set({ backupState: false })
     }
   },
 
-  // 从WebDAV同步
   syncFromWebDAV: async () => {
-    const { url, username, password, path } = get()
-    get().setSyncState(true)
+      const { url, username, password, path, syncState } = get()
+
+      if (syncState) {
+        throw new Error('Sync is already in progress')
+      }
+
+      set({ syncState: true })
+
     try {
-      const result = await invoke<string>('webdav_sync', {
-        url,
-        username,
-        password,
-        path
+        return await invoke<string>('webdav_sync', {
+          url, username, password, path
       })
-      
-      return result
-    } catch (error) {
-      console.error('WebDAV connection test failed:', error)
-      return ''
     } finally {
-      get().setSyncState(false)
+        set({ syncState: false })
+      }
+    },
+
+    //创建WebDAVD目录
+    createWebDAVDir: async (dirPath: string) => {
+      const { url, username, password } = get()
+
+      if (!url || !username || !password) {
+        throw new Error('WebDAV connection parameters are incomplete')
+      }
+
+      await invoke('webdav_create_dir', {
+        url, username, password, path: dirPath
+      })
     }
   }
-}))
+})
 
 export default useWebDAVStore


### PR DESCRIPTION



<!--
感谢您的贡献！以下信息将帮助我们更快地审查和合并您的代码。
-->

### 概述 (Overview)

本次更新主要修复了 **WebDAV** 功能中存在的若干连接和兼容性问题，并对底层的网络堆栈进行了显著优化。这旨在解决社区反馈的 #207 和 #310 问题，全面提升 WebDAV 同步的稳定性、兼容性和性能。

### 具体修复与改进 (Specific Fixes & Improvements)

*   **扩展的服务器兼容性**:
    *   修复了与**坚果云**的连接问题，确保同步流畅。
    *   增强了对多种**自建服务器**的兼容性，已通过 `ugeek/webdav`, `bytemark/webdav` 等常见方案的测试。

*   **网络连接与性能优化**:
    *   **智能双栈连接**: 实现了对域名 A (IPv4) 和 AAAA (IPv6) 记录的并发解析和连接尝试，优先使用更快的可用连接。
    *   **绕过 "Happy Eyeballs" 延迟**: 优化了连接策略，避免了传统双栈连接算法可能引入的延迟，尤其改善了 IPv6 网络的连接速度。
    *   **优化的超时逻辑**: 调整了网络请求的超时设置，使其在弱网或高延迟环境下更加健壮。

*   **用户体验改进**:
    *   为“测试连接”功能加入了**防抖机制**，防止用户因快速重复点击而发送不必要的网络请求，提升了界面的响应性和稳定性。

### 已测试环境 (Tested Environments)

本次提交已在以下 **PC 端** 环境中测试通过：

*   **云服务**:
    *   坚果云 (Jianguoyun)
*   **自建服务器 (Docker)**:
    *   `ugeek/webdav`
    *   `bytemark/webdav`
    *   `visity/webdav` (原版无密码验证模式)

### 待测试项 (To Be Tested)

*   **移动端 (App)** 的 WebDAV 同步功能。
*   **国外的 WebDAV 服务** (如 `pCloud`, `Box` 等) 的兼容性。

### 依赖项变更 (Dependency Changes)

*   `tokio = { version = "1", features = ["full"] }`
*   `url = "2.5"`

---

Closes #207
Closes #310