### PR TITLE
feat: 文件创建时空格自动替换为下划线

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The writing section is divided into two parts: **File Manager** and **Markdown E
 
 ## Contribute
 
-- [Read contribution guide](https://notegen.top/en/CONTRIBUTING.html)
+- [Read contribution guide](https://notegen.top/en/docs/contributing)
 - [Update plans](https://github.com/codexu/note-gen/issues/46)
 - [Submit bugs or improvement suggestions](https://github.com/codexu/note-gen/issues)
 - [Discussions](https://github.com/codexu/note-gen/discussions)

--- a/src/app/core/article/file/file-item.tsx
+++ b/src/app/core/article/file/file-item.tsx
@@ -57,56 +57,57 @@ export function FileItem({ item }: { item: DirTree }) {
       title: item.name,
       kind: 'warning',
     });
-    
     // 如果用户确认删除，则继续执行
     if (answer) {
-      // 获取工作区路径信息
-      const { getFilePathOptions, getWorkspacePath } = await import('@/lib/workspace')
-      const workspace = await getWorkspacePath()
-      
-      // 根据工作区类型正确删除文件
-      const pathOptions = await getFilePathOptions(path)
-      if (workspace.isCustom) {
-        // 自定义工作区
-        try {
+      try {
+        // 获取工作区路径信息
+        const { getFilePathOptions, getWorkspacePath } = await import('@/lib/workspace')
+        const workspace = await getWorkspacePath()
+        
+        // 根据工作区类型正确删除文件
+        const pathOptions = await getFilePathOptions(path)
+        
+        if (workspace.isCustom) {
+          // 自定义工作区
           await remove(pathOptions.path)
-        } catch (e) {
-          console.error(e);
-        }
-      } else {
-        // 默认工作区
-        try {
+        } else {
+          // 默认工作区
           await remove(pathOptions.path, { baseDir: pathOptions.baseDir })
-        } catch (e) {
-          console.error(e);
         }
-      }
-      
-      // 更新文件树
-      if (currentFolder) {
-        const index = currentFolder.children?.findIndex(file => file.name === item.name)
-        if (index !== undefined && index !== -1 && currentFolder.children) {
-          const current = currentFolder.children[index]
-          if (current.sha) {
-            current.isLocale = false
-          } else {
-            currentFolder.children.splice(index, 1)
+        
+        // 更新文件树
+        if (currentFolder) {
+          const index = currentFolder.children?.findIndex(file => file.name === item.name)
+          if (index !== undefined && index !== -1 && currentFolder.children) {
+            const current = currentFolder.children[index]
+            if (current.sha) {
+              current.isLocale = false
+            } else {
+              currentFolder.children.splice(index, 1)
+            }
+          }
+        } else {
+          const index = cacheTree.findIndex(file => file.name === item.name)
+          if (index !== undefined && index !== -1) {
+            const current = cacheTree[index]
+            if (current.sha) {
+              current.isLocale = false
+            } else {
+              cacheTree.splice(index, 1)
+            }
           }
         }
-      } else {
-        const index = cacheTree.findIndex(file => file.name === item.name)
-        if (index !== undefined && index !== -1) {
-          const current = cacheTree[index]
-          if (current.sha) {
-            current.isLocale = false
-          } else {
-            cacheTree.splice(index, 1)
-          }
-        }
+        setFileTree(cacheTree)
+        setActiveFilePath('')
+        setCurrentArticle('')
+      } catch (error) {
+        console.error('Delete file failed:', error)
+        toast({
+          title: t('context.deleteLocalFile'),
+          description: '删除文件失败: ' + error,
+          variant: 'destructive'
+        })
       }
-      setFileTree(cacheTree)
-      setActiveFilePath('')
-      setCurrentArticle('')
     }
   }
 
@@ -192,7 +193,7 @@ export function FileItem({ item }: { item: DirTree }) {
         // 重命名现有文件
         // 获取源路径和目标路径
         const oldPathOptions = await getFilePathOptions(path)
-        const newPathRelative = path.split('/').slice(0, -1).join('/') + '/' + name
+        const newPathRelative = path.split('/').slice(0, -1).join('/') + '/' + displayName
         const newPathOptions = await getFilePathOptions(newPathRelative)
         
         // 根据工作区类型执行重命名操作
@@ -206,7 +207,7 @@ export function FileItem({ item }: { item: DirTree }) {
         }
       } else {
         // 创建新文件
-        let newFilePath = name
+        let newFilePath = sanitizedName
         if (!newFilePath.endsWith('.md')) {
           newFilePath += '.md'
         }
@@ -258,7 +259,9 @@ export function FileItem({ item }: { item: DirTree }) {
           }
         } else {
           const index = cacheTree.findIndex(item => item.name === '')
-          cacheTree.splice(index, 1)
+          if (index !== -1) {
+            cacheTree.splice(index, 1)
+          }
         }
       } else {
         // 对于重命名现有文件，如果没有输入新名称，则保持原状态
@@ -488,7 +491,7 @@ export function FileItem({ item }: { item: DirTree }) {
           <ContextMenuItem disabled={!item.sha} inset className="text-red-900" onClick={handleDeleteSyncFile}>
             {t('context.deleteSyncFile')}
           </ContextMenuItem>
-          <ContextMenuItem disabled={!item.isLocale} inset className="text-red-900" onClick={handleDeleteFile}>
+          <ContextMenuItem disabled={!item.isLocale || item.name === ''} inset className="text-red-900" onClick={handleDeleteFile}>
             {t('context.deleteLocalFile')}
           </ContextMenuItem>
         </ContextMenuContent>

--- a/src/app/core/article/file/file-item.tsx
+++ b/src/app/core/article/file/file-item.tsx
@@ -157,15 +157,17 @@ export function FileItem({ item }: { item: DirTree }) {
   }
 
   async function handleRename() {
-    setName(name.replace(/ /g, '_')) // github 存储空格会报错，替换为下划线
+    // 统一处理：将空格替换为下划线，确保本地和远程文件名一致
+    const sanitizedName = name.replace(/\s+/g, '_')
+    setName(sanitizedName)
   
     // 获取工作区路径信息
     const { getFilePathOptions, getWorkspacePath } = await import('@/lib/workspace')
     const workspace = await getWorkspacePath()
   
-    if (name && name.trim() !== '' && name !== item.name) {
+    if (sanitizedName && sanitizedName.trim() !== '' && sanitizedName !== item.name) {
       // 确保新文件名如果需要.md后缀则添加后缀
-      let displayName = name;
+      let displayName = sanitizedName;
       if (item.name === '' && !displayName.endsWith('.md')) {
         displayName += '.md';
       }
@@ -415,7 +417,11 @@ export function FileItem({ item }: { item: DirTree }) {
                   className="h-5 rounded-sm text-xs px-1 font-normal flex-1 mr-1"
                   value={name}
                   onBlur={handleRename}
-                  onChange={(e) => { setName(e.target.value) }}
+                  onChange={(e) => { 
+                    // 实时将空格替换为下划线，保持与同步逻辑一致
+                    const sanitizedValue = e.target.value.replace(/\s+/g, '_')
+                    setName(sanitizedValue)
+                  }}
                   onKeyDown={(e) => {
                     if (e.code === 'Enter' && !e.nativeEvent.isComposing) {
                       handleRename()

--- a/src/app/core/article/file/file-manager.tsx
+++ b/src/app/core/article/file/file-manager.tsx
@@ -91,6 +91,7 @@ export function FileManager() {
           const text = await file.text()
           // 处理文件名，将空格替换为下划线以保持一致性
           const sanitizedFileName = file.name.replace(/\s+/g, '_')
+          
           await writeTextFile(`article/${sanitizedFileName}`, text, { baseDir: BaseDirectory.AppData })
           addFile({
             name: sanitizedFileName,

--- a/src/app/core/article/file/file-manager.tsx
+++ b/src/app/core/article/file/file-manager.tsx
@@ -89,9 +89,11 @@ export function FileManager() {
         // 接受 markdown 和图片文件
         if (file.name.endsWith('.md')) {
           const text = await file.text()
-          await writeTextFile(`article/${file.name}`, text, { baseDir: BaseDirectory.AppData })
+          // 处理文件名，将空格替换为下划线以保持一致性
+          const sanitizedFileName = file.name.replace(/\s+/g, '_')
+          await writeTextFile(`article/${sanitizedFileName}`, text, { baseDir: BaseDirectory.AppData })
           addFile({
-            name: file.name,
+            name: sanitizedFileName,
             isEditing: false,
             isLocale: true,
             isDirectory: false,

--- a/src/app/core/article/file/file-manager.tsx
+++ b/src/app/core/article/file/file-manager.tsx
@@ -91,7 +91,7 @@ export function FileManager() {
           const text = await file.text()
           // 处理文件名，将空格替换为下划线以保持一致性
           const sanitizedFileName = file.name.replace(/\s+/g, '_')
-          
+
           await writeTextFile(`article/${sanitizedFileName}`, text, { baseDir: BaseDirectory.AppData })
           addFile({
             name: sanitizedFileName,
@@ -102,12 +102,13 @@ export function FileManager() {
             isSymlink: false
           })
         } else if (file.name.match(/\.(jpg|jpeg|png|gif|bmp|webp|svg)$/i)) {
-          // 处理图片文件
+          // 处理图片文件，同样需要处理文件名以保持一致性
           const arrayBuffer = await file.arrayBuffer()
           const uint8Array = new Uint8Array(arrayBuffer)
-          await writeFile(`article/${file.name}`, uint8Array, { baseDir: BaseDirectory.AppData })
+          const sanitizedImageFileName = file.name.replace(/\s+/g, '_')
+          await writeFile(`article/${sanitizedImageFileName}`, uint8Array, { baseDir: BaseDirectory.AppData })
           addFile({
-            name: file.name,
+            name: sanitizedImageFileName,
             isEditing: false,
             isLocale: true,
             isDirectory: false,

--- a/src/app/core/article/file/folder-item/index.tsx
+++ b/src/app/core/article/file/folder-item/index.tsx
@@ -49,30 +49,32 @@ export function FolderItem({ item }: { item: DirTree }) {
 
   // 创建或修改文件夹名称
   async function handleRename() {
-    setName(name.replace(/ /g, '_')) // github 存储空格会报错，替换为下划线
+    // 统一处理：将空格替换为下划线，确保本地和远程文件名一致
+    const sanitizedName = name.replace(/\s+/g, '_')
+    setName(sanitizedName)
   
     // 获取工作区路径信息
     const { getFilePathOptions, getWorkspacePath } = await import('@/lib/workspace')
     const workspace = await getWorkspacePath()
   
     // 修改文件夹名称
-    if (name && name !== item.name && item.name !== '') {
+    if (sanitizedName && sanitizedName !== item.name && item.name !== '') {
       // 更新缓存树中的名称
       if (parentFolder && parentFolder.children) {
         const folderIndex = parentFolder?.children?.findIndex(folder => folder.name === item.name)
         if (folderIndex !== undefined && folderIndex !== -1) {
-          parentFolder.children[folderIndex].name = name
+          parentFolder.children[folderIndex].name = sanitizedName
           parentFolder.children[folderIndex].isEditing = false
         }
       } else {
         const folderIndex = cacheTree.findIndex(folder => folder.name === item.name)
-        cacheTree[folderIndex].name = name
+        cacheTree[folderIndex].name = sanitizedName
         cacheTree[folderIndex].isEditing = false
       }
       
       // 获取源路径和目标路径
       const oldPathOptions = await getFilePathOptions(path)
-      const newPathOptions = await getFilePathOptions(`${path.split('/').slice(0, -1).join('/')}/${name}`)
+      const newPathOptions = await getFilePathOptions(`${path.split('/').slice(0, -1).join('/')}/${sanitizedName}`)
       
       // 根据工作区类型执行重命名操作
       if (workspace.isCustom) {
@@ -85,11 +87,7 @@ export function FolderItem({ item }: { item: DirTree }) {
       }
     } else {
       // 新建文件夹
-      if (name !== '') {
-        // 将空格替换为下划线
-        const sanitizedName = name.replace(/ /g, '_')
-        setName(sanitizedName) // 更新状态中的名称
-        
+      if (sanitizedName !== '') {
         // 检查文件夹是否已存在
         const newFolderPath = `${path}/${sanitizedName}`
         const pathOptions = await getFilePathOptions(newFolderPath)
@@ -234,7 +232,11 @@ export function FolderItem({ item }: { item: DirTree }) {
                     className="h-5 rounded-sm text-xs px-1 font-normal flex-1 mr-1"
                     value={name}
                     onBlur={handleRename}
-                    onChange={(e) => { setName(e.target.value) }}
+                    onChange={(e) => { 
+                      // 实时将空格替换为下划线，保持与同步逻辑一致
+                      const sanitizedValue = e.target.value.replace(/\s+/g, '_')
+                      setName(sanitizedValue)
+                    }}
                     onKeyDown={(e) => {
                       if (e.code === 'Enter') {
                         handleRename()

--- a/src/app/core/article/file/folder-item/index.tsx
+++ b/src/app/core/article/file/folder-item/index.tsx
@@ -130,7 +130,9 @@ export function FolderItem({ item }: { item: DirTree }) {
           }
         } else {
           const index = cacheTree.findIndex(item => item.name === '')
-          cacheTree.splice(index, 1)
+          if (index !== -1) {
+            cacheTree.splice(index, 1)
+          }
         }
       }
     } 

--- a/src/app/core/record/chat/note-output.tsx
+++ b/src/app/core/record/chat/note-output.tsx
@@ -38,7 +38,9 @@ export function NoteOutput({chat}: {chat: Chat}) {
 
   async function handleTransform() {
     const content = chat?.content || ''
-    const writePath = `${path}/${title.replace(/ /g, '_')}`
+    // 统一处理：将空格替换为下划线，确保本地和远程文件名一致
+    const sanitizedTitle = title.replace(/\s+/g, '_')
+    const writePath = `${path}/${sanitizedTitle}`
     
     // Use workspace functions instead of directly using BaseDirectory.AppData
     const pathOptions = await getFilePathOptions(writePath)

--- a/src/lib/gitlab.ts
+++ b/src/lib/gitlab.ts
@@ -15,7 +15,8 @@ import {
 } from './gitlab.types';
 import { RepoNames } from './github.types';
 
-// 获取 Gitlab 实例的 API 基础 URL
+// 获取 Gitlab 实例的 API 基础 URL 
+
 async function getGitlabApiBaseUrl(): Promise<string> {
   const store = await Store.load('store.json');
   const instanceType = await store.get<GitlabInstanceType>('gitlabInstanceType') || GitlabInstanceType.OFFICIAL;


### PR DESCRIPTION
最近在用的时候发现同步到远程本地创建的带空格的文件名同步到git，会重复新增一个空格转为下划线的文件，看了一下git不支持，倒是很合理，既然这样感觉不如直接创建本地文件的时候就加空格算了。故实现了一下。