### PR TITLE
fix(#664): 修复目录或文件名包含特殊字符‘&’时，笔记同步功能失效问题

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -71,7 +71,7 @@ export async function uploadFile(
       _filename = `${id}.${ext}`
     }
     // 将空格转换成下划线
-    _filename = _filename.replace(/\s/g, '_')
+    _filename = encodeURIComponent(_filename.replace(/\s/g, '_'))
     const _path = path ? `/${path}`: ''
     
     // 设置请求头
@@ -124,7 +124,7 @@ export async function getFiles({ path, repo }: { path: string, repo: string }) {
   if (!accessToken) return;
   
   const githubUsername = await store.get('githubUsername')
-  path = path.replace(/\s/g, '_')
+  path = encodeURIComponent(path.replace(/\s/g, '_'))
   
   // 获取代理设置
   const proxyUrl = await store.get<string>('proxy')
@@ -203,7 +203,7 @@ export async function deleteFile(
       proxy
     };
     
-    const url = `https://api.github.com/repos/${githubUsername}/${repo}/contents/${path}`;
+    const url = `https://api.github.com/repos/${githubUsername}/${repo}/contents/${encodeURIComponent(path)}`;
     const response = await fetch(url, requestOptions);
     
     if (response.status >= 200 && response.status < 300) {
@@ -224,7 +224,7 @@ export async function getFileCommits({ path, repo }: { path: string, repo: strin
   if (!accessToken) return;
   
   const githubUsername = await store.get('githubUsername')
-  path = path.replace(/\s/g, '_')
+  path = encodeURIComponent(path.replace(/\s/g, '_'))
   
   // 获取代理设置
   const proxyUrl = await store.get<string>('proxy')


### PR DESCRIPTION
issue: [#664](https://github.com/codexu/note-gen/issues/664)
之前文件名和路径只是通过将空格替换为下划线来过滤。这不足以处理其他特殊字符（例如`&`），这会导致GitHub API请求url出错。

这是个简单提交，在`uploadFile`、`getFiles`、`deleteFile`和`getFileCommits`函数中使用`encodeURIComponent`封装了文件名和路径。这确保所有特殊字符都被正确编码，防止API在处理具有非标准名称的文件时失败。


Previously, filenames and paths were only sanitized by replacing spaces with underscores. This was insufficient for handling other special characters (e.g., `&`), which could lead to broken GitHub API request URLs.

This commit wraps filenames and paths with `encodeURIComponent` in the `uploadFile`, `getFiles`, `deleteFile`, and `getFileCommits` functions. This ensures all special characters are properly encoded, preventing API failures when handling files with non-standard names.