### PR TITLE
fix: 删除标记时同步刷新标签统计

### DIFF
--- a/src/app/core/main/editor/markdown/md-editor.tsx
+++ b/src/app/core/main/editor/markdown/md-editor.tsx
@@ -38,6 +38,7 @@ export function MdEditor() {
   const { currentArticle, saveCurrentArticle, loading, isPulling, activeFilePath, matchPosition, setMatchPosition, setActiveFilePath, loadFileTree, setCurrentArticle, readArticle } = useArticleStore()
   const { assetsPath, contentTextScale } = useSettingStore()
   const { fetchMarks } = useMarkStore()
+  const { fetchTags, getCurrentTag } = useTagStore()
   const [floatBarPosition, setFloatBarPosition] = useState<{left: number, top: number} | null>(null)
   const [selectedText, setSelectedText] = useState<string>('')
   const { theme } = useTheme()
@@ -1113,6 +1114,9 @@ export function MdEditor() {
               await delMark(mark.id)
               // 刷新记录列表
               await fetchMarks()
+              // 刷新标签统计
+               await fetchTags()
+              getCurrentTag()
             }
           } catch (error) {
             console.error('Failed to delete mark:', error)


### PR DESCRIPTION
删除记录后需要调用 fetchTags 和 getCurrentTag 来更新标签统计数据，确保界面显示与数据状态一致。
<img width="1404" height="847" alt="image" src="https://github.com/user-attachments/assets/170899be-d592-4351-a2e8-7a67aa26292a" />

