### PR TITLE
fix(file-manager): allow system paste while renaming

### DIFF
--- a/src/app/core/main/file/index.tsx
+++ b/src/app/core/main/file/index.tsx
@@ -46,6 +46,22 @@ function useFileManagerShortcuts() {
     }
   }, [currentPlatform])
 
+  const isEditableTarget = useCallback((target: EventTarget | null): boolean => {
+    if (!(target instanceof HTMLElement)) {
+      return false
+    }
+
+    if (target.isContentEditable) {
+      return true
+    }
+
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+      return true
+    }
+
+    return !!target.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]')
+  }, [])
+
   // 获取当前激活的 item（文件或文件夹）
   const getActiveItem = useCallback((): { path: string; isDirectory: boolean; isLocale: boolean; name: string; sha?: string } | null => {
     if (!activeFilePath) return null
@@ -80,6 +96,10 @@ function useFileManagerShortcuts() {
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     // 移动端不处理快捷键
     if (isMobileDevice()) {
+      return
+    }
+
+    if (isEditableTarget(e.target)) {
       return
     }
 
@@ -158,7 +178,7 @@ function useFileManagerShortcuts() {
       window.dispatchEvent(event)
       return
     }
-  }, [isFocused, getActiveItem, isModKey, currentPlatform, setClipboardItem])
+  }, [isFocused, getActiveItem, isModKey, currentPlatform, setClipboardItem, isEditableTarget])
 
   // 注册全局快捷键
   useEffect(() => {


### PR DESCRIPTION
## 背景
在文件管理器中打开笔记的同时重命名文件/文件夹，`Ctrl/Cmd+V` 无法将系统剪贴板文本粘贴到输入框。

## 根因
文件管理器的全局 `keydown` 快捷键处理会拦截 `Ctrl/Cmd+V`，并触发文件级粘贴事件（`filemanager-paste`），导致输入框默认文本粘贴行为被 `preventDefault` 覆盖。

## 变更
- 在文件管理器快捷键处理里新增可编辑目标检测：
  - `input`
  - `textarea`
  - `select`
  - `contenteditable`
  - `role="textbox"`
- 当焦点位于可编辑控件时，跳过文件级快捷键处理，保留系统默认粘贴行为。

## 影响
- 重命名输入框内 `Ctrl/Cmd+V` 恢复为文本粘贴。
- 非编辑状态下的文件管理器快捷键（复制/剪切/粘贴/删除/重命名）行为不变。

## 验证
- `pnpm -s tsc --noEmit` 通过。
### Before
<img width="3840" height="2077" alt="d52246acb7b0ceb99119f279e575e30d" src="https://github.com/user-attachments/assets/c56aee1a-cc67-428c-9202-468779bd145c" />

### After
<img width="3840" height="2076" alt="970ab394ab0f02ebc417654f63edda93" src="https://github.com/user-attachments/assets/50549612-86f9-4567-b14f-eb532736f956" />

