### PR TITLE
feat(ai): add 阿里云百炼（Coding Plan） provider with static model fallback

### DIFF
--- a/src/app/core/setting/ai/modelSelect.tsx
+++ b/src/app/core/setting/ai/modelSelect.tsx
@@ -15,7 +15,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { AiConfig } from "../config";
+import { AiConfig, baseAiConfig } from "../config";
 import { Store } from "@tauri-apps/plugin-store";
 import emitter from "@/lib/emitter";
 
@@ -56,7 +56,22 @@ export default function ModelSelect(
     if (requestId !== currentRequestIdRef.current) return
     
     if (!models) return
-    setList(models)
+    // 如果API返回空列表，尝试使用静态模型列表作为后备
+    if (models.length === 0 && model) {
+      const baseConfig = baseAiConfig.find(c => c.baseURL === model.baseURL)
+      if (baseConfig?.staticModels?.length) {
+        setList(baseConfig.staticModels.map(id => ({
+          id,
+          object: 'model' as const,
+          created: 0,
+          owned_by: baseConfig.key,
+        })))
+      } else {
+        setList(models)
+      }
+    } else {
+      setList(models)
+    }
     
     // 如果没有传入aiConfig，则从store中设置model值
     if (!aiConfig && setModel) {

--- a/src/app/core/setting/ai/page.tsx
+++ b/src/app/core/setting/ai/page.tsx
@@ -47,6 +47,11 @@ export default function AiPage() {
   
   // 当前选中的AI配置
   const currentConfig = userCustomModels.find(model => model.key === selectedAiConfig)
+
+  const getConfigDisplayTitle = (config?: AiConfig) => {
+    if (!config) return t('selectConfig')
+    return baseAiConfig.find(item => item.baseURL === config.baseURL)?.title || config.title
+  }
   
   const parseHeadersToKeyValue = (headers: Record<string, string> = {}) => {
     return Object.entries(headers).map(([key, value]) => ({
@@ -282,13 +287,13 @@ export default function AiPage() {
                 <Select value={selectedAiConfig} onValueChange={setSelectedAiConfig}>
                   <SelectTrigger className="w-full">
                     <div className="flex items-center gap-2">
-                      {currentConfig?.title || t('selectConfig')}
+                      {getConfigDisplayTitle(currentConfig)}
                     </div>
                   </SelectTrigger>
                   <SelectContent>
                     {userCustomModels.map((item) => (
                       <SelectItem value={item.key} key={item.key}>
-                        {item.title}
+                        {getConfigDisplayTitle(item)}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -331,7 +336,7 @@ export default function AiPage() {
                         />
                       )}
                       <div>
-                        <div className="font-medium">{currentConfig.title}</div>
+                        <div className="font-medium">{baseAiConfig.find(config => config.baseURL === currentConfig.baseURL)?.title || currentConfig.title}</div>
                         <div className="text-sm text-muted-foreground">{currentConfig.baseURL}</div>
                       </div>
                     </div>

--- a/src/app/core/setting/config.tsx
+++ b/src/app/core/setting/config.tsx
@@ -131,6 +131,7 @@ export interface AiConfig {
   apiKeyUrl?: string
   customHeaders?: Record<string, string>
   models?: ModelConfig[]
+  staticModels?: string[]
   // 保持向后兼容
   model?: string
   temperature?: number
@@ -231,6 +232,23 @@ const baseAiConfig: AiConfig[] = [
     baseURL: 'https://ai.gitee.com/v1',
     icon: 'https://s2.loli.net/2025/09/15/ih7aTnGPvELFsVc.png',
     apiKeyUrl: 'https://ai.gitee.com/'
+  },
+  {
+    key: 'bailian-coding',
+    title: '阿里云百炼（Coding Plan）',
+    baseURL: 'https://coding.dashscope.aliyuncs.com/v1',
+    icon: 'https://unpkg.com/@lobehub/icons-static-png/light/Bailian.png',
+    apiKeyUrl: 'https://dashscope.console.aliyun.com/apiKey',
+    staticModels: [
+      'qwen3.5-plus',
+      'qwen3-max-2026-01-23',
+      'qwen3-coder-next',
+      'qwen3-coder-plus',
+      'glm-5',
+      'glm-4.7',
+      'kimi-k2.5',
+      'MiniMax-M2.5',
+    ]
   },
 ]
 

--- a/src/lib/ai/utils.ts
+++ b/src/lib/ai/utils.ts
@@ -3,6 +3,7 @@ import { Store } from "@tauri-apps/plugin-store";
 import OpenAI from 'openai';
 import { AiConfig } from "@/app/core/setting/config";
 import { readFile } from "@tauri-apps/plugin-fs";
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 
 /**
  * 获取当前的prompt内容
@@ -279,6 +280,7 @@ export async function createOpenAIClient(AiConfig?: AiConfig) {
     apiKey: apiKey || '',
     baseURL: baseURL,
     dangerouslyAllowBrowser: true,
+    fetch: tauriFetch as unknown as typeof globalThis.fetch,
     defaultHeaders:{
       "x-stainless-arch": null,
       "x-stainless-lang": null,


### PR DESCRIPTION
新增并完善阿里云百炼（Coding Plan）供应商支持：接入官方 OpenAI 兼容 `baseURL`（`https://coding.dashscope.aliyuncs.com/v1`）、统一供应商标题与展示文案，并修复自定义供应商接入 Coding Plan 时的跨域问题（在 `createOpenAIClient` 中统一注入 Tauri `@tauri-apps/plugin-http` 的 `fetch`，避免浏览器 CORS 限制）；同时针对 Coding Plan 不支持 `/v1/models` 的限制增加静态模型回退（`qwen3.5-plus`、`qwen3-max-2026-01-23`、`qwen3-coder-next`、`qwen3-coder-plus`、`glm-5`、`glm-4.7`、`kimi-k2.5`、`MiniMax-M2.5`），使“新模型”配置支持下拉选择并提升整体可用性。

<img width="3840" height="2076" alt="image" src="https://github.com/user-attachments/assets/8b3de807-7ded-49e8-8397-6c1bcaf8ac46" />


<img width="3840" height="2076" alt="image" src="https://github.com/user-attachments/assets/dc3ea905-706b-42c8-be49-a6d528fd9971" />

<img width="3840" height="2074" alt="image" src="https://github.com/user-attachments/assets/18701df0-a1ab-4bd0-b2e0-92485fd43bda" />


