### PR TITLE
fix(#234): 修复Ubuntu 22.04构建AppImage失败

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,12 +232,25 @@ jobs:
         include:
           - platform: 'macos-latest'
             args: '--target aarch64-apple-darwin'
+            name: 'macos-arm64'
+            bundlePath: 'src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/NoteGen_*.dmg'
           - platform: 'macos-latest'
             args: '--target x86_64-apple-darwin'
+            name: 'macos-x64'
+            bundlePath: 'src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/NoteGen_*.dmg'
           - platform: 'ubuntu-24.04'
             args: '--bundles deb,rpm'
+            name: 'linux-deb-rpm'
+            bundlePath: 'src-tauri/target/release/bundle/(rpm|deb)/NoteGen_*.(rpm|deb)'
+          - platform: 'ubuntu-22.04'
+            args: '--bundles appimage'
+            name: 'linux-appimage'
+            bundlePath: 'src-tauri/target/release/bundle/appimage/NoteGen_*.AppImage'
+            noSign: true
           - platform: 'windows-latest'
             args: ''
+            name: 'windows'
+            bundlePath: 'src-tauri\target\release\bundle\(nsis|msi)\NoteGen_*.(exe|msi)'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -260,8 +273,11 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-24.04'
+        if: startsWith(matrix.platform, 'ubuntu-')
         run: |
+          if [ "${{ matrix.platform }}" = "ubuntu-22.04" ]; then
+            sudo add-apt-repository -y ppa:pipewire-debian/pipewire-upstream
+          fi
           sudo apt-get update
           sudo apt-get install pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libgbm-dev libappindicator3-dev librsvg2-dev patchelf
 
@@ -310,6 +326,14 @@ jobs:
           args: ${{ matrix.args }}
 
       
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}
+          path: |
+            ${{ matrix.bundlePath }}
+          if-no-files-found: warn
+
       - name: Generate release tag
         id: save_tag
         if: matrix.platform == 'ubuntu-24.04'


### PR DESCRIPTION
1. 参考 https://github.com/itsddvn/beautiFULLshot/commit/54c2535c0f736020a7798c6cce1911406d6e95ec 修复Ubuntu 22.04构建AppImage失败
2. 保留构建制品，以方便下载测试