### PR TITLE
fix(#1062): 修复 convertImageToBase64 无法解析 convertFileSrc 生成的 URL

### DIFF
--- a/src/lib/ai/utils.ts
+++ b/src/lib/ai/utils.ts
@@ -3,6 +3,7 @@ import { Store } from "@tauri-apps/plugin-store";
 import type OpenAI from 'openai';
 import { AiConfig } from "@/app/core/setting/config";
 import { readFile } from "@tauri-apps/plugin-fs";
+import { platform } from "@tauri-apps/plugin-os";
 import { createTauriOpenAIClient, type OpenAICompatibleClient } from "./tauri-client";
 
 /**
@@ -101,31 +102,28 @@ export async function convertImageToBase64(imageUrl: string): Promise<string | n
     if (imageUrl.startsWith('data:image')) {
       return imageUrl
     }
-    
-    // 从 Tauri URL 中提取文件路径
-    // convertFileSrc 生成的 URL 格式类似: tauri://localhost/path 或 asset://localhost/path
+
+    // 从 convertFileSrc 生成的 URL 中提取文件路径
     let filePath = imageUrl
-    
-    // 移除 tauri:// 或 asset:// 协议前缀
-    if (imageUrl.startsWith('tauri://localhost/')) {
-      filePath = imageUrl.replace('tauri://localhost/', '')
-    } else if (imageUrl.startsWith('asset://localhost/')) {
-      filePath = imageUrl.replace('asset://localhost/', '')
-    } else if (imageUrl.startsWith('http://tauri.localhost/')) {
-      filePath = imageUrl.replace('http://tauri.localhost/', '')
+
+    try {
+      const url = new URL(imageUrl)
+      filePath = decodeURIComponent(url.pathname)
+      if (platform() === 'windows' && filePath.startsWith('/')) {
+        filePath = filePath.substring(1)
+      }
+    } catch {
+      filePath = imageUrl
     }
-    
-    // URL 解码
-    filePath = decodeURIComponent(filePath)
-    
+
     // 读取文件
     const fileData = await readFile(filePath)
-    
+
     // 转换为 base64
     const base64 = btoa(
       new Uint8Array(fileData).reduce((data, byte) => data + String.fromCharCode(byte), '')
     )
-    
+
     // 根据文件扩展名确定 MIME 类型
     let mimeType = 'image/png'
     if (filePath.toLowerCase().endsWith('.jpg') || filePath.toLowerCase().endsWith('.jpeg')) {
@@ -135,7 +133,7 @@ export async function convertImageToBase64(imageUrl: string): Promise<string | n
     } else if (filePath.toLowerCase().endsWith('.webp')) {
       mimeType = 'image/webp'
     }
-    
+
     return `data:${mimeType};base64,${base64}`
   } catch (error) {
     console.error('Failed to convert image to base64:', error)


### PR DESCRIPTION
```markdown
## 问题

Issue #1062

附加本地图片发送给视觉模型时，报错 `Failed to convert image to base64: URL is not a valid path`，模型回复无法识别图片内容。

## 原因

`convertImageToBase64()` 使用硬编码前缀匹配（仅处理 `tauri://localhost/` 和 `asset://localhost/`）来提取文件路径，但 `convertFileSrc()` 在不同平台/配置下会生成多种 URL 格式（如 `http://asset.localhost/`、`https://tauri.localhost/` 等），未被覆盖的格式导致路径解析失败。

## 修复

- 使用 `new URL()` 替代硬编码前缀匹配，兼容所有 URL 格式
- 通过 `@tauri-apps/plugin-os` 的 `platform()` 处理 Windows 路径前缀（`new URL().pathname` 在 Windows 上返回 `/C:/...`，需去掉前导 `/`）

## 测试

- Windows 11 上验证：附加本地图片后，视觉模型（GLM-4.1V）成功识别图片内容
```
