### PR TITLE
fix: clamp endLine to file length in line-based editor replacement

### DIFF
--- a/src/lib/agent/react-diff-helpers.ts
+++ b/src/lib/agent/react-diff-helpers.ts
@@ -23,13 +23,18 @@ export function replaceLinesInRange(
   const endIndex = actualEndLine - 1
 
   // 验证行号范围
-  if (startIndex < 0 || endIndex >= lines.length) {
+  if (startIndex < 0 || startIndex >= lines.length) {
     throw new Error(`无效的行号范围: ${startLine}-${endLine}，文件共 ${lines.length} 行`)
   }
 
+  // Clamp endIndex to the last line to handle minor line-count discrepancies
+  // caused by content normalization (e.g. trailing newline stripping) between
+  // get_editor_content and the actual replacement call.
+  const clampedEndIndex = Math.min(endIndex, lines.length - 1)
+
   // 替换指定行
   const before = lines.slice(0, startIndex)
-  const after = lines.slice(endIndex + 1)
+  const after = lines.slice(clampedEndIndex + 1)
   return [...before, ...newLines, ...after].join('\n')
 }
 
@@ -109,13 +114,16 @@ export function deleteLinesInRange(
   const endIndex = actualEndLine - 1
 
   // 验证行号范围
-  if (startIndex < 0 || endIndex >= lines.length) {
+  if (startIndex < 0 || startIndex >= lines.length) {
     throw new Error(`无效的行号范围: ${startLine}-${endLine}，文件共 ${lines.length} 行`)
   }
 
+  // Clamp endIndex to the last line to handle minor line-count discrepancies.
+  const clampedEndIndex = Math.min(endIndex, lines.length - 1)
+
   // 删除指定行
   const before = lines.slice(0, startIndex)
-  const after = lines.slice(endIndex + 1)
+  const after = lines.slice(clampedEndIndex + 1)
 
   return [...before, ...after].join('\n')
 }


### PR DESCRIPTION
Fixes #1054

## Problem

When the AI uses `replace_editor_content` with line-based mode (e.g. `startLine: 1`, `endLine: totalLines` for a document-wide rewrite), a minor line-count discrepancy between what `get_editor_content` reported and what `editor.getMarkdown()` returns at replacement time causes an uncaught error:

```
Uncaught Error: 无效的行号范围: 1-24，文件共 22 行
```

This happens because `editor.getMarkdown()` normalises the content (e.g. strips trailing blank lines) so the actual line count can be slightly lower than `totalLines` the AI received earlier.

## Solution

Instead of throwing when `endLine` exceeds the file length, **clamp `endLine` to the last line** of the file. This preserves the intent of the operation ("replace up to the end of the document") without crashing.

The same fix is applied to `deleteLinesInRange` for consistency.

## Testing

- Open a markdown file, ask the AI to rewrite the whole document.
- Previously this would hang/crash with the "无效的行号范围" error.
- After the fix, the replacement completes successfully even when the AI's `endLine` is slightly larger than the current line count.