### PR TITLE
fix: correct outline active heading detection and scroll-to-center on click

### DIFF
--- a/src/app/core/main/editor/markdown/outline.tsx
+++ b/src/app/core/main/editor/markdown/outline.tsx
@@ -229,8 +229,9 @@ export function Outline({
     const scrollTop = editorElement.scrollTop
     const viewportTop = scrollTop + 100 // Add some offset for better UX
 
-    // Find the first heading that is above or near the viewport top
-    for (const heading of headings) {
+    // Find the last heading that is above or near the viewport top (iterate in reverse)
+    for (let i = headings.length - 1; i >= 0; i--) {
+      const heading = headings[i]
       const domNode = editor.view.nodeDOM(heading.pos) as HTMLElement | undefined
       if (domNode) {
         const rect = domNode.getBoundingClientRect()
@@ -296,10 +297,15 @@ export function Outline({
       // Then set the selection to the heading position
       editor.commands.setTextSelection(targetPos)
 
-      // Then scroll into view
+      // Then scroll into view, centering the heading in the editor
       // Use setTimeout to ensure the selection is applied first
       setTimeout(() => {
-        editor.commands.scrollIntoView()
+        const domNode = editor.view.nodeDOM(targetPos) as HTMLElement | undefined
+        if (domNode) {
+          domNode.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        } else {
+          editor.commands.scrollIntoView()
+        }
       }, 0)
 
       onHeadingSelect?.()


### PR DESCRIPTION
Fixes #1039

## Problem

Two bugs in the outline panel:

1. **Wrong active heading highlight on scroll**: The `findActiveHeadingByScroll` function iterated headings from first to last, returning the first heading whose position was at or above the viewport. With multiple headings scrolled past, this always returned the topmost heading instead of the most recently passed one, causing the highlight to be out of sync with the actual scroll position.

2. **Heading not centered when clicked**: Clicking a heading in the outline used `editor.commands.scrollIntoView()`, which only guarantees the selection is visible (often placing it at the bottom edge of the viewport) rather than centering it.

## Solution

1. Changed `findActiveHeadingByScroll` to iterate in **reverse order** (last to first) so it returns the last heading whose top is at or above the viewport — i.e., the heading the user is currently reading.

2. Changed `scrollToHeading` to use `domNode.scrollIntoView({ behavior: 'smooth', block: 'center' })` so the target heading is scrolled to the center of the editor viewport.

## Testing

- Open a document with multiple headings spanning more than one screen
- Scroll through the document and verify the outline panel highlights the correct heading
- Click headings in the outline and verify they scroll to the center of the editor