### PR TITLE
fix(#1072): 改进 skill 导入功能，支持嵌套目录结构

### DIFF
--- a/CREATE_PR_INSTRUCTIONS.md
+++ b/CREATE_PR_INSTRUCTIONS.md
@@ -1,0 +1,136 @@
+# 🚀 创建PR的详细步骤
+
+## 📋 当前状态
+- ✅ 代码已推送到：`LevisBale0824/note-gen:fix/1072`
+- ✅ PR描述已准备：`pr-description.md`
+- ⏳ 需要在GitHub上创建PR以关联issue #1072
+
+## 🔗 立即创建PR
+
+### 方法1：直接打开链接（最简单）
+
+点击这个链接：
+```
+https://github.com/codexu/note-gen/compare/dev...LevisBale0824:note-gen:fix/1072
+```
+
+### 方法2：手动创建
+
+1. 打开 https://github.com/codexu/note-gen
+2. 点击 **"Pull requests"**
+3. 点击 **"New pull request"**
+4. 点击 **"compare across forks"**
+5. 选择：
+   - **base repository**: `codexu/note-gen`
+   - **base branch**: `dev`
+   - **head repository**: `LevisBale0824/note-gen`
+   - **compare branch**: `fix/1072`
+
+## 📝 填写PR信息
+
+### PR Title
+```
+fix(#1072): Improve skill import to support nested directory structures
+```
+
+### PR Description
+
+复制以下内容（包含 `Fixes #1072`，这会自动关联issue）：
+
+```markdown
+## Type of Change
+
+- [x] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## Related Issue
+
+Fixes #1072
+
+## Description
+
+### Summary
+
+Improve skill import functionality to support nested directory structures in ZIP files and ignore macOS metadata directories.
+
+### Changes Made
+
+- Added `find_skill_root()` function to recursively search for SKILL.md files
+- Added `is_ignored_zip_metadata_dir()` function to ignore __MACOSX directories
+- Improved import logic to handle flexible directory structures
+- Enhanced directory move/copy logic with better error handling
+- Improved error messages for better user feedback
+
+### Technical Details
+
+Modified `src-tauri/src/skills.rs`:
+- Recursive search for SKILL.md to determine skill root directory
+- Automatically handles different levels of ZIP archive structures
+- Falls back to copy operation when move fails (cross-device scenarios)
+- More reliable cleanup of temporary directories
+
+## Testing
+
+### How to Test
+
+1. Create a skill ZIP file with nested directory structure
+2. Upload ZIP through NoteGen import feature
+3. Verify skill imports correctly and is usable
+4. Test with macOS ZIP files (containing __MACOSX directory)
+
+### Test Results
+
+- [x] Tested locally
+- [ ] Tested on Windows
+- [ ] Tested on macOS
+- [ ] Tested on Linux
+- [ ] Build succeeds with `pnpm tauri build`
+
+## Checklist
+
+- [x] My code follows the style guidelines of this project
+- [x] I have performed a self-review of my code
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [x] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [x] Any dependent changes have been merged and published in downstream modules
+- [x] I have checked my code and corrected any misspellings
+
+## Additional Notes
+
+This fix primarily targets the skill import functionality to handle more complex ZIP archive directory structures, specifically:
+- Supports skills nested within subdirectories
+- Ignores macOS automatically generated __MACOSX metadata directories
+- Improved error handling and user feedback
+```
+
+## ✅ 创建PR后会发生什么？
+
+1. **自动关联issue**: `Fixes #1072` 会自动将PR与issue #1072关联
+2. **issue页面更新**: issue #1072 页面会显示这个PR
+3. **合并后自动关闭**: 当PR被合并时，issue #1072 会自动关闭
+4. **通知维护者**: NoteGen维护者会收到PR通知进行代码审查
+
+## 🎯 关键点
+
+**一定要确保PR描述中有这一行**：
+```markdown
+Fixes #1072
+```
+
+这行代码会触发GitHub的自动关联和关闭功能。
+
+## 📞 如果遇到问题
+
+如果链接打不开或创建失败，请检查：
+1. 你的分支是否已经推送到 `LevisBale0824/note-gen`
+2. 你是否是 `codexu/note-gen` 的协作者
+3. 网络连接是否正常
+
+---
+
+**现在就点击上面的链接创建PR吧！** 🚀

--- a/SKILL_UPDATE_COMPLETE.md
+++ b/SKILL_UPDATE_COMPLETE.md
@@ -1,0 +1,117 @@
+# ✅ Skill 更新完成！
+
+## 📋 改进内容
+
+### 1. 使用完整的Issue URL
+**之前**: 使用issue编号，如 `Fixes #1072`
+**现在**: 使用完整URL，如 `Fixes https://github.com/codexu/note-gen/issues/1072`
+
+### 2. 用户需要提供完整链接
+所有脚本现在要求用户提供完整的GitHub issue URL，而不是只提供issue编号。
+
+### 3. 自动提取issue编号
+脚本会自动从提供的URL中提取issue编号用于分支命名。
+
+## 🔄 更新的文件
+
+### 脚本文件
+1. ✅ `auto_pr.py` - 接受issue URL，提取编号
+2. ✅ `create_pr_automated.py` - 完整自动化，使用issue URL
+3. ✅ `create_pr_api.py` - GitHub API创建，使用issue URL
+4. ✅ `SKILL.md` - 更新使用说明
+
+### 文档文件
+1. ✅ `pr-description.md` - 更新为完整issue URL
+2. ✅ `CREATE_PR_INSTRUCTIONS.md` - 更新说明
+
+## 🚀 新的使用方法
+
+### 方法1: 直接运行脚本
+```bash
+python C:/Users/Min/.agents/skills/notegen-contribution-helper/scripts/auto_pr.py "https://github.com/codexu/note-gen/issues/1072" fix "改进skill导入功能" "修改src-tauri/src/skills.rs，添加递归查找功能"
+```
+
+### 方法2: 对我说
+```
+帮我创建PR修复 https://github.com/codexu/note-gen/issues/1072，这是bug修复：改进skill导入功能
+```
+
+### 方法3: 通过GitHub API（需要token）
+```bash
+python C:/Users/Min/.agents/skills/notegen-contribution-helper/scripts/create_pr_api.py "https://github.com/codexu/note-gen/issues/1072" fix "改进skill导入功能"
+```
+
+## 📝 PR模板变化
+
+### 之前
+```markdown
+## Related Issue
+Fixes #1072
+```
+
+### 现在
+```markdown
+## Related Issue
+Fixes https://github.com/codexu/note-gen/issues/1072
+```
+
+## ✅ 优势
+
+1. **更明确** - 完整URL让人一眼就能看到是哪个issue
+2. **可点击** - PR页面中的链接可以直接点击跳转到issue
+3. **灵活性** - 支持不同仓库的issue URL
+4. **自动关联** - GitHub仍然能识别并自动关闭issue
+
+## 🎯 当前PR状态
+
+### 已准备好的PR
+- **分支**: `fix/1072`
+- **Issue**: https://github.com/codexu/note-gen/issues/1072
+- **标题**: `fix(#1072): Improve skill import to support nested directory structures`
+- **描述**: `pr-description.md` (已更新为完整URL)
+
+### 创建PR链接
+```
+https://github.com/codexu/note-gen/compare/dev...LevisBale0824:note-gen:fix/1072
+```
+
+## 🔧 技术实现
+
+### URL提取函数
+所有脚本都包含 `extract_issue_number()` 函数：
+```python
+def extract_issue_number(issue_url):
+    """Extract issue number from GitHub issue URL."""
+    import re
+    # 支持:
+    # https://github.com/codexu/note-gen/issues/1072
+    # https://github.com/codexu/note-gen/pull/1072
+    # codexu/note-gen#1072
+    match = re.search(r'/issues/(\d+)', issue_url)
+    if not match:
+        match = re.search(r'/pull/(\d+)', issue_url)
+    if not match:
+        match = re.search(r'#(\d+)', issue_url)
+    if match:
+        return match.group(1)
+    return None
+```
+
+## 📞 完全自动化功能
+
+skill现在支持完全自动化：
+1. ✅ 自动创建分支
+2. ✅ 自动提交代码
+3. ✅ 自动推送到远程
+4. ✅ 自动生成PR描述（包含完整issue URL）
+5. ✅ 自动创建PR（如果有GitHub token）
+
+## 🎉 总结
+
+- ✅ 所有脚本已更新为使用完整issue URL
+- ✅ 用户体验更好（URL可点击，更明确）
+- ✅ 向后兼容（仍然支持 #1072 格式）
+- ✅ 灵活性强（支持各种URL格式）
+- ✅ GitHub自动关联功能保持完整
+
+现在用户只需要提供完整的issue URL，skill会自动处理所有细节！🚀

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,68 @@
+## Type of Change
+
+- [x] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## Related Issue
+
+Fixes https://github.com/codexu/note-gen/issues/1072
+
+## Description
+
+### Summary
+
+Improve skill import functionality to support nested directory structures in ZIP files and ignore macOS metadata directories.
+
+### Changes Made
+
+- Added `find_skill_root()` function to recursively search for SKILL.md files
+- Added `is_ignored_zip_metadata_dir()` function to ignore __MACOSX directories
+- Improved import logic to handle flexible directory structures
+- Enhanced directory move/copy logic with better error handling
+- Improved error messages for better user feedback
+
+### Technical Details
+
+Modified `src-tauri/src/skills.rs`:
+- Recursive search for SKILL.md to determine skill root directory
+- Automatically handles different levels of ZIP archive structures
+- Falls back to copy operation when move fails (cross-device scenarios)
+- More reliable cleanup of temporary directories
+
+## Testing
+
+### How to Test
+
+1. Create a skill ZIP file with nested directory structure
+2. Upload ZIP through NoteGen import feature
+3. Verify skill imports correctly and is usable
+4. Test with macOS ZIP files (containing __MACOSX directory)
+
+### Test Results
+
+- [x] Tested locally
+- [ ] Tested on Windows
+- [ ] Tested on macOS
+- [ ] Tested on Linux
+- [ ] Build succeeds with `pnpm tauri build`
+
+## Checklist
+
+- [x] My code follows the style guidelines of this project
+- [x] I have performed a self-review of my code
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [x] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [x] Any dependent changes have been merged and published in downstream modules
+- [x] I have checked my code and corrected any misspellings
+
+## Additional Notes
+
+This fix primarily targets the skill import functionality to handle more complex ZIP archive directory structures, specifically:
+- Supports skills nested within subdirectories
+- Ignores macOS automatically generated __MACOSX metadata directories
+- Improved error handling and user feedback

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use std::fs;
+use std::path::{Path, PathBuf};
 use tauri::{command, AppHandle, Manager};
 use zip::ZipArchive;
 
@@ -54,56 +54,78 @@ pub async fn import_skill_zip(app_handle: AppHandle, zip_path: String) -> Result
         }
     }
 
-    // 查找解压后的目录
-    let entries = fs::read_dir(&temp_dir)
-        .map_err(|e| format!("Failed to read temp directory: {}", e))?;
-
-    let mut skill_name = String::new();
-
-    // 查找包含 SKILL.md 的目录
-    for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
-        let path = entry.path();
-
-        if path.is_dir() {
-            // 检查是否包含 SKILL.md
-            let skill_md = path.join("SKILL.md");
-            if skill_md.exists() {
-                skill_name = path.file_name()
-                    .and_then(|n| n.to_str())
-                    .ok_or("Failed to get skill directory name")?
-                    .to_string();
-
-                let dest_path = skills_dir.join(&skill_name);
-
-                // 如果目标目录已存在，先删除
-                if dest_path.exists() {
-                    fs::remove_dir_all(&dest_path)
-                        .map_err(|e| format!("Failed to remove existing skill directory: {}", e))?;
-                }
-
-                // 移动目录到 skills 目录
-                fs::rename(&path, &dest_path)
-                    .or_else(|_| {
-                        // 如果 rename 失败（可能跨文件系统），尝试复制
-                        copy_dir_recursive(&path, &dest_path)
-                    })
-                    .map_err(|e| format!("Failed to move skill directory: {}", e))?;
-
-                break;
-            }
+    let skill_root = match find_skill_root(&temp_dir)? {
+        Some(path) => path,
+        None => {
+            let _ = fs::remove_dir_all(&temp_dir);
+            return Err("No valid skill found in zip file. A valid skill must contain a SKILL.md file.".to_string());
         }
+    };
+
+    let skill_name = if skill_root == temp_dir {
+        Path::new(&zip_path)
+            .file_stem()
+            .and_then(|n| n.to_str())
+            .filter(|n| !n.trim().is_empty())
+            .ok_or("Failed to get skill directory name from zip file")?
+            .to_string()
+    } else {
+        skill_root.file_name()
+            .and_then(|n| n.to_str())
+            .ok_or("Failed to get skill directory name")?
+            .to_string()
+    };
+
+    let dest_path = skills_dir.join(&skill_name);
+    if dest_path.exists() {
+        fs::remove_dir_all(&dest_path)
+            .map_err(|e| format!("Failed to remove existing skill directory: {}", e))?;
+    }
+
+    if skill_root == temp_dir {
+        copy_dir_recursive(&skill_root, &dest_path)
+            .map_err(|e| format!("Failed to copy skill directory: {}", e))?;
+    } else {
+        fs::rename(&skill_root, &dest_path)
+            .or_else(|_| copy_dir_recursive(&skill_root, &dest_path))
+            .map_err(|e| format!("Failed to move skill directory: {}", e))?;
     }
 
     // 清理临时目录
     fs::remove_dir_all(&temp_dir)
         .map_err(|e| format!("Failed to remove temp directory: {}", e))?;
 
-    if skill_name.is_empty() {
-        return Err("No valid skill found in zip file. A valid skill must contain a SKILL.md file.".to_string());
+    Ok(skill_name)
+}
+
+fn find_skill_root(root: &Path) -> Result<Option<PathBuf>, String> {
+    if root.join("SKILL.md").is_file() {
+        return Ok(Some(root.to_path_buf()));
     }
 
-    Ok(skill_name)
+    let entries = fs::read_dir(root)
+        .map_err(|e| format!("Failed to read directory: {}", e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+        let path = entry.path();
+        if !path.is_dir() || is_ignored_zip_metadata_dir(&path) {
+            continue;
+        }
+
+        if let Some(skill_root) = find_skill_root(&path)? {
+            return Ok(Some(skill_root));
+        }
+    }
+
+    Ok(None)
+}
+
+fn is_ignored_zip_metadata_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|name| name == "__MACOSX")
+        .unwrap_or(false)
 }
 
 // 递归复制目录的辅助函数


### PR DESCRIPTION
Fixes https://github.com/codexu/note-gen/issues/1072
 - 重构 find_skill_root 函数：递归查找 SKILL.md，支持 zip 内多层嵌套目录结构（之前只查找一层）
 - 支持 zip 根目录直接包含 SKILL.md 的情况（用 zip 文件名作为 skill 目录名）
 - 新增 is_ignored_zip_metadata_dir 函数，过滤 __MACOSX 等 macOS 元数据目录