### PR TITLE
fix(#1073): 修复GitHub文件夹同步会覆盖仓库其他目录的问题

### DIFF
--- a/src/lib/sync/folder-sync-payload.ts
+++ b/src/lib/sync/folder-sync-payload.ts
@@ -11,6 +11,11 @@ export interface GithubTreeEntry {
   content: string
 }
 
+export interface GithubCreateTreePayload {
+  base_tree: string
+  tree: GithubTreeEntry[]
+}
+
 export interface GitlabCommitAction {
   action: 'create' | 'update'
   file_path: string
@@ -25,6 +30,16 @@ export function buildGithubTreeEntries(files: FolderSyncFilePayload[]): GithubTr
     type: 'blob',
     content: file.content,
   }))
+}
+
+export function buildGithubCreateTreePayload(
+  files: FolderSyncFilePayload[],
+  baseTreeSha: string
+): GithubCreateTreePayload {
+  return {
+    base_tree: baseTreeSha,
+    tree: buildGithubTreeEntries(files),
+  }
 }
 
 export function buildGitlabCommitActions(files: FolderSyncFilePayload[]): GitlabCommitAction[] {

--- a/src/lib/sync/folder-sync.ts
+++ b/src/lib/sync/folder-sync.ts
@@ -9,7 +9,7 @@ import { getGiteaApiBaseUrl } from './gitea'
 import { s3Upload } from './s3'
 import { webdavUpload } from './webdav'
 import { S3Config, WebDAVConfig } from '@/types/sync'
-import { buildGithubTreeEntries, buildGitlabCommitActions } from './folder-sync-payload'
+import { buildGithubCreateTreePayload, buildGitlabCommitActions } from './folder-sync-payload'
 
 export interface FolderSyncResult {
   success: boolean
@@ -206,23 +206,36 @@ export class FolderSync {
     const proxyUrl = await store.get<string>('proxy')
     const proxy: Proxy | undefined = proxyUrl ? { all: proxyUrl } : undefined
 
-    // 构建 tree
-    // 注意：GitHub API 不允许同时提供 sha 和 content
-    // 只提供 content，让 GitHub 自动处理（新文件创建 blob，已存在文件也会创建新的 blob）
-    const tree = buildGithubTreeEntries(files)
-
     const headers = new Headers()
     headers.append('Authorization', `Bearer ${accessToken}`)
     headers.append('Accept', 'application/vnd.github+json')
     headers.append('X-GitHub-Api-Version', '2022-11-28')
     headers.append('Content-Type', 'application/json')
 
-    // 1. 创建 tree
+    // 1. 获取当前 commit 和对应的 tree，后续提交必须基于它，避免覆盖仓库其他目录
+    const refUrl = `https://api.github.com/repos/${githubUsername}/${repo}/git/ref/heads/main`
+    const refResponse = await fetch(refUrl, { method: 'GET', headers, proxy })
+    if (!refResponse.ok) return false
+    const refData = await refResponse.json()
+    const parentCommitSha = refData.object.sha
+
+    const parentCommitUrl = `https://api.github.com/repos/${githubUsername}/${repo}/git/commits/${parentCommitSha}`
+    const parentCommitResponse = await fetch(parentCommitUrl, { method: 'GET', headers, proxy })
+    if (!parentCommitResponse.ok) return false
+    const parentCommitData = await parentCommitResponse.json()
+    const baseTreeSha = parentCommitData.tree?.sha
+
+    if (!baseTreeSha) {
+      console.error('获取 GitHub base tree 失败')
+      return false
+    }
+
+    // 2. 基于当前 tree 创建新 tree，只覆盖本次同步的文件
     const createTreeUrl = `https://api.github.com/repos/${githubUsername}/${repo}/git/trees`
     const treeResponse = await fetch(createTreeUrl, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ tree }),
+      body: JSON.stringify(buildGithubCreateTreePayload(files, baseTreeSha)),
       proxy,
     })
 
@@ -232,13 +245,6 @@ export class FolderSync {
     }
 
     const treeData = await treeResponse.json()
-
-    // 2. 获取当前 commit SHA
-    const refUrl = `https://api.github.com/repos/${githubUsername}/${repo}/git/ref/heads/main`
-    const refResponse = await fetch(refUrl, { method: 'GET', headers, proxy })
-    if (!refResponse.ok) return false
-    const refData = await refResponse.json()
-    const parentCommitSha = refData.object.sha
 
     // 3. 创建 commit
     const commitUrl = `https://api.github.com/repos/${githubUsername}/${repo}/git/commits`
@@ -267,7 +273,7 @@ export class FolderSync {
       headers,
       body: JSON.stringify({
         sha: commitData.sha,
-        force: true,
+        force: false,
       }),
       proxy,
     })


### PR DESCRIPTION
- 新增 GithubCreateTreePayload 接口，支持基于 base_tree 创建 tree
- 修改同步逻辑：先获取当前 commit 和 base tree sha
- 创建 tree 时使用 base_tree 参数，只覆盖本次同步的文件
- 将强制推送从 force: true 改为 force: false

修复前：GitHub 同步会覆盖整个仓库的所有文件
修复后：只覆盖本次同步涉及的文件，不影响其他目录

Fixes https://github.com/codexu/note-gen/issues/1073