### PR TITLE
fix: preserve filename input and add macOS voice diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ skills-lock.json
 
 # testing
 /coverage
+/tmp/
 *.test.*
 
 # next.js

--- a/public/doubao-input-debug.html
+++ b/public/doubao-input-debug.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Doubao Input Debug</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background: Canvas;
+        color: CanvasText;
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        border-bottom: 1px solid color-mix(in srgb, CanvasText 18%, transparent);
+        padding-bottom: 16px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 20px;
+      }
+
+      p {
+        margin: 6px 0 0;
+        color: color-mix(in srgb, CanvasText 62%, transparent);
+        font-size: 14px;
+      }
+
+      button {
+        border: 1px solid color-mix(in srgb, CanvasText 22%, transparent);
+        border-radius: 6px;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+        padding: 8px 12px;
+      }
+
+      .grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        margin-top: 20px;
+      }
+
+      label,
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        font-size: 14px;
+        font-weight: 600;
+      }
+
+      textarea,
+      input,
+      [contenteditable] {
+        border: 1px solid color-mix(in srgb, CanvasText 22%, transparent);
+        border-radius: 6px;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        font-weight: 400;
+        padding: 10px;
+      }
+
+      textarea,
+      [contenteditable] {
+        min-height: 128px;
+      }
+
+      table {
+        border-collapse: collapse;
+        font-size: 12px;
+        margin-top: 20px;
+        table-layout: fixed;
+        width: 100%;
+      }
+
+      th,
+      td {
+        border-bottom: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+        padding: 8px;
+        text-align: left;
+        vertical-align: top;
+        word-break: break-word;
+      }
+
+      th {
+        position: sticky;
+        top: 0;
+        background: Canvas;
+      }
+
+      .log-wrap {
+        border: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+        border-radius: 6px;
+        margin-top: 12px;
+        max-height: 46vh;
+        overflow: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <h1>Doubao Input Debug</h1>
+          <p>Plain DOM receiver probe for Tauri/WKWebView.</p>
+        </div>
+        <div>
+          <button id="clear" type="button">Clear</button>
+          <button id="copy" type="button">Copy logs</button>
+        </div>
+      </header>
+
+      <section class="grid">
+        <label>
+          Raw textarea
+          <textarea id="raw-textarea" name="raw-textarea" rows="6"></textarea>
+        </label>
+
+        <label>
+          Plain input
+          <input id="plain-input" name="plain-input" />
+        </label>
+
+        <div class="field">
+          Content editable
+          <div id="contenteditable" contenteditable="true" role="textbox"></div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Event log</h2>
+        <div class="log-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th style="width: 52px">#</th>
+                <th style="width: 120px">event</th>
+                <th style="width: 180px">target</th>
+                <th style="width: 160px">inputType/key</th>
+                <th>value</th>
+              </tr>
+            </thead>
+            <tbody id="logs"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const eventTypes = [
+        "focus",
+        "beforeinput",
+        "input",
+        "change",
+        "compositionstart",
+        "compositionupdate",
+        "compositionend",
+        "keydown",
+        "keyup",
+        "paste",
+      ];
+      const logBody = document.getElementById("logs");
+      const logs = [];
+      let nextId = 1;
+      const collectorUrl = "http://127.0.0.1:45678/input-log";
+
+      function describeTarget(target) {
+        if (!(target instanceof HTMLElement)) return "unknown";
+        const id = target.id ? "#" + target.id : "";
+        const name = target.getAttribute("name");
+        return target.tagName.toLowerCase() + id + (name ? '[name="' + name + '"]' : "");
+      }
+
+      function readValue(target) {
+        if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+          return target.value;
+        }
+        if (target instanceof HTMLElement && target.isContentEditable) {
+          return target.textContent || "";
+        }
+        return "";
+      }
+
+      function eventData(event) {
+        if (event instanceof InputEvent) {
+          return {
+            data: event.data || "",
+            inputType: event.inputType || "",
+            isComposing: event.isComposing,
+          };
+        }
+        if (event instanceof CompositionEvent) {
+          return { data: event.data || "", inputType: "", isComposing: undefined };
+        }
+        if (event instanceof KeyboardEvent) {
+          return { data: event.key || "", inputType: "", isComposing: event.isComposing };
+        }
+        return { data: "", inputType: "", isComposing: undefined };
+      }
+
+      function render() {
+        logBody.innerHTML = logs
+          .slice()
+          .reverse()
+          .map((log) => {
+            const detail = [log.inputType, log.data, log.isComposing ? "composing" : ""]
+              .filter(Boolean)
+              .join(" ");
+            return (
+              "<tr>" +
+              "<td>" + log.id + "</td>" +
+              "<td>" + log.type + "</td>" +
+              "<td>" + log.target + "</td>" +
+              "<td>" + detail + "</td>" +
+              "<td>" + log.value + "</td>" +
+              "</tr>"
+            );
+          })
+          .join("");
+      }
+
+      function reportLog(log) {
+        const img = new Image();
+        img.referrerPolicy = "no-referrer";
+        img.src = collectorUrl + "?entry=" + encodeURIComponent(JSON.stringify(log));
+      }
+
+      function appendLog(event) {
+        const detail = eventData(event);
+        const log = {
+          id: nextId++,
+          time: new Date().toISOString(),
+          type: event.type,
+          target: describeTarget(event.target),
+          value: readValue(event.target),
+          data: detail.data,
+          inputType: detail.inputType,
+          isComposing: detail.isComposing,
+        };
+        logs.push(log);
+        if (logs.length > 200) logs.shift();
+        reportLog(log);
+        render();
+      }
+
+      for (const type of eventTypes) {
+        document.addEventListener(type, appendLog, true);
+      }
+
+      document.getElementById("clear").addEventListener("click", () => {
+        logs.length = 0;
+        nextId = 1;
+        document.getElementById("raw-textarea").value = "";
+        document.getElementById("plain-input").value = "";
+        document.getElementById("contenteditable").textContent = "";
+        render();
+      });
+
+      document.getElementById("copy").addEventListener("click", async () => {
+        await navigator.clipboard.writeText(JSON.stringify(logs, null, 2));
+      });
+
+      window.addEventListener("DOMContentLoaded", () => {
+        const rawTextarea = document.getElementById("raw-textarea");
+        if (rawTextarea instanceof HTMLTextAreaElement) {
+          rawTextarea.focus();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/public/doubao-input-debug.spec.mjs
+++ b/public/doubao-input-debug.spec.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+test('static Doubao probe can report input events to a local collector', async () => {
+  const html = await readFile(new URL('./doubao-input-debug.html', import.meta.url), 'utf8')
+
+  assert.match(html, /127\.0\.0\.1:45678\/input-log/)
+  assert.match(html, /reportLog/)
+  assert.match(html, /rawTextarea\.focus/)
+})

--- a/scripts/compare-doubao-input-logs.mjs
+++ b/scripts/compare-doubao-input-logs.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+function countEvents(logs, type) {
+  return logs.filter((log) => log?.type === type).length
+}
+
+function hasEvent(logs, type) {
+  return logs.some((log) => log?.type === type)
+}
+
+function readFinalValues(payload) {
+  return payload?.summary?.finalValues || {}
+}
+
+function summarizePayload(payload) {
+  const logs = Array.isArray(payload?.logs) ? payload.logs : []
+  return {
+    label: payload?.metadata?.label || payload?.summary?.label || '',
+    totalEvents: logs.length,
+    focusEvents: countEvents(logs, 'focus'),
+    beforeInputEvents: countEvents(logs, 'beforeinput'),
+    inputEvents: countEvents(logs, 'input'),
+    manualVoiceAttemptConfirmed: hasEvent(logs, 'manual-voice-attempt-confirmed'),
+    finalValues: readFinalValues(payload),
+  }
+}
+
+function computeVerdict(unpatched, patched) {
+  if (unpatched.inputEvents === 0 && patched.inputEvents > 0) {
+    return 'patched_only_input'
+  }
+  if (unpatched.inputEvents > 0 && patched.inputEvents > 0) {
+    return 'both_have_input'
+  }
+  if (unpatched.inputEvents === 0 && patched.inputEvents === 0) {
+    return 'neither_has_input'
+  }
+  return 'unpatched_only_input'
+}
+
+export function compareInputLogPayloads({ unpatched, patched }) {
+  const unpatchedSummary = summarizePayload(unpatched)
+  const patchedSummary = summarizePayload(patched)
+  const isExperimentValid = unpatchedSummary.manualVoiceAttemptConfirmed
+    && patchedSummary.manualVoiceAttemptConfirmed
+  const verdict = isExperimentValid
+    ? computeVerdict(unpatchedSummary, patchedSummary)
+    : 'invalid_experiment'
+
+  return {
+    verdict,
+    isExperimentValid,
+    supportsWryKeyDownHypothesis: isExperimentValid && verdict === 'patched_only_input',
+    unpatched: unpatchedSummary,
+    patched: patchedSummary,
+  }
+}
+
+function readPayload(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function readArg(name, fallback) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return fallback
+  return process.argv[index + 1] ?? fallback
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const unpatchedPath = readArg('--unpatched', 'tmp/doubao-unpatched-logs.json')
+  const patchedPath = readArg('--patched', 'tmp/doubao-patched-logs.json')
+  const result = compareInputLogPayloads({
+    unpatched: readPayload(unpatchedPath),
+    patched: readPayload(patchedPath),
+  })
+  console.log(JSON.stringify(result, null, 2))
+}

--- a/scripts/compare-doubao-input-logs.spec.mjs
+++ b/scripts/compare-doubao-input-logs.spec.mjs
@@ -1,0 +1,83 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { compareInputLogPayloads } from './compare-doubao-input-logs.mjs'
+
+function payload(label, logs) {
+  return {
+    metadata: { label },
+    logs,
+    summary: {
+      label,
+      totalEvents: logs.length,
+      eventCounts: logs.reduce((counts, log) => {
+        counts[log.type] = (counts[log.type] || 0) + 1
+        return counts
+      }, {}),
+      finalValues: logs.reduce((values, log) => {
+        if (log.target && typeof log.value === 'string') {
+          values[log.target] = log.value
+        }
+        return values
+      }, {}),
+    },
+  }
+}
+
+test('supports Wry keyDown hypothesis when patched receives input and unpatched does not', () => {
+  const result = compareInputLogPayloads({
+    unpatched: payload('unpatched-wry', [
+      { type: 'manual-voice-attempt-confirmed', target: 'terminal', value: '' },
+      { type: 'focus', target: 'textarea#raw-textarea', value: '' },
+    ]),
+    patched: payload('patched-wry', [
+      { type: 'manual-voice-attempt-confirmed', target: 'terminal', value: '' },
+      { type: 'focus', target: 'textarea#raw-textarea', value: '' },
+      { type: 'beforeinput', target: 'textarea#raw-textarea', value: '', inputType: 'insertText' },
+      { type: 'input', target: 'textarea#raw-textarea', value: '豆包语音', inputType: 'insertText' },
+    ]),
+  })
+
+  assert.equal(result.verdict, 'patched_only_input')
+  assert.equal(result.isExperimentValid, true)
+  assert.equal(result.supportsWryKeyDownHypothesis, true)
+  assert.equal(result.unpatched.inputEvents, 0)
+  assert.equal(result.patched.inputEvents, 1)
+  assert.equal(result.unpatched.manualVoiceAttemptConfirmed, true)
+  assert.equal(result.patched.manualVoiceAttemptConfirmed, true)
+})
+
+test('does not support Wry keyDown hypothesis when both builds receive input', () => {
+  const result = compareInputLogPayloads({
+    unpatched: payload('unpatched-wry', [
+      { type: 'manual-voice-attempt-confirmed', target: 'terminal', value: '' },
+      { type: 'input', target: 'textarea#raw-textarea', value: 'ok' },
+    ]),
+    patched: payload('patched-wry', [
+      { type: 'manual-voice-attempt-confirmed', target: 'terminal', value: '' },
+      { type: 'input', target: 'textarea#raw-textarea', value: 'ok' },
+    ]),
+  })
+
+  assert.equal(result.verdict, 'both_have_input')
+  assert.equal(result.isExperimentValid, true)
+  assert.equal(result.supportsWryKeyDownHypothesis, false)
+})
+
+test('marks comparison invalid when a manual voice attempt is not confirmed', () => {
+  const result = compareInputLogPayloads({
+    unpatched: payload('unpatched-wry', [
+      { type: 'focus', target: 'textarea#raw-textarea', value: '' },
+    ]),
+    patched: payload('patched-wry', [
+      { type: 'manual-voice-attempt-confirmed', target: 'terminal', value: '' },
+      { type: 'input', target: 'textarea#raw-textarea', value: 'ok' },
+    ]),
+  })
+
+  assert.equal(result.verdict, 'invalid_experiment')
+  assert.equal(result.isExperimentValid, false)
+  assert.equal(result.supportsWryKeyDownHypothesis, false)
+  assert.equal(result.unpatched.manualVoiceAttemptConfirmed, false)
+  assert.equal(result.patched.manualVoiceAttemptConfirmed, true)
+})

--- a/scripts/diagnose-wry-keydown.mjs
+++ b/scripts/diagnose-wry-keydown.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const cargoLockPath = join(process.cwd(), 'src-tauri', 'Cargo.lock')
+const wryParentRelativePath = join('src', 'wkwebview', 'class', 'wry_web_view_parent.rs')
+
+export function readCargoLockPackageVersion(lockText, packageName) {
+  const packageBlocks = lockText.split(/\n(?=\[\[package\]\]\n)/)
+  for (const block of packageBlocks) {
+    if (new RegExp(`^name = "${packageName}"$`, 'm').test(block)) {
+      const versionMatch = block.match(/^version = "([^"]+)"$/m)
+      if (versionMatch) return versionMatch[1]
+    }
+  }
+  return null
+}
+
+export function findRegistryPackageSource(packageName, version) {
+  const registrySrcRoot = join(homedir(), '.cargo', 'registry', 'src')
+  if (!existsSync(registrySrcRoot)) return null
+
+  for (const registryDir of readdirSync(registrySrcRoot)) {
+    const packagePath = join(registrySrcRoot, registryDir, `${packageName}-${version}`)
+    const sourcePath = join(packagePath, wryParentRelativePath)
+    if (existsSync(sourcePath)) return sourcePath
+  }
+
+  return null
+}
+
+export function extractKeyDownMethod(sourceText) {
+  const methodStart = sourceText.indexOf('fn key_down(&self, event: &NSEvent)')
+  if (methodStart === -1) return ''
+
+  const drawStart = sourceText.indexOf('#[cfg(target_os = "macos")]', methodStart + 1)
+  return sourceText.slice(methodStart, drawStart === -1 ? undefined : drawStart)
+}
+
+export function analyzeKeyDownSource(sourceText) {
+  const keyDownMethod = extractKeyDownMethod(sourceText)
+
+  return {
+    hasKeyDownOverride: keyDownMethod.length > 0,
+    callsPerformKeyEquivalent: keyDownMethod.includes('performKeyEquivalent(event)'),
+    checksPerformKeyEquivalentReturnValue: keyDownMethod.includes('if menu.performKeyEquivalent(event)'),
+    hasCommandOrControlGuard:
+      keyDownMethod.includes('NSEventModifierFlags::Command') ||
+      keyDownMethod.includes('NSEventModifierFlags::Control'),
+    mentionsOptionExclusion: /Option|Alt/.test(keyDownMethod),
+    callsInterpretKeyEvents: keyDownMethod.includes('interpretKeyEvents'),
+  }
+}
+
+export function patchWryKeyDownSource(sourceText) {
+  let patched = sourceText
+    .replace(
+      'use objc2_app_kit::{NSApplication, NSEvent, NSView, NSWindow, NSWindowButton};',
+      [
+        'use objc2_app_kit::{',
+        '  NSApplication, NSEvent, NSEventModifierFlags, NSView, NSWindow, NSWindowButton,',
+        '};',
+      ].join('\n'),
+    )
+    .replace(
+      'use objc2_foundation::NSRect;',
+      'use objc2_foundation::{NSArray, NSRect};',
+    )
+
+  const keyDownMethod = extractKeyDownMethod(patched)
+  assert.ok(keyDownMethod, 'Wry key_down method not found')
+
+  const guardedKeyDownMethod = `fn key_down(&self, event: &NSEvent) {
+      let flags = unsafe { event.modifierFlags() };
+
+      // Only attempt menu key equivalents when Command or Control modifiers
+      // are held. Option (Alt) is intentionally excluded because Option+key
+      // combinations are used for special/dead-key input.
+      if flags.intersects(NSEventModifierFlags::Command | NSEventModifierFlags::Control) {
+        let mtm = MainThreadMarker::new().unwrap();
+        let app = NSApplication::sharedApplication(mtm);
+        unsafe {
+          if let Some(menu) = app.mainMenu() {
+            if menu.performKeyEquivalent(event) {
+              return;
+            }
+          }
+        }
+      }
+
+      unsafe {
+        self.interpretKeyEvents(&NSArray::from_slice(&[event]));
+      }
+    }
+
+    `
+
+  return patched.replace(keyDownMethod, guardedKeyDownMethod)
+}
+
+export function preparePatchedWrySource({ sourceRoot, outputRoot }) {
+  assert.ok(sourceRoot, 'sourceRoot is required')
+  assert.ok(outputRoot, 'outputRoot is required')
+  const sourceFile = join(sourceRoot, wryParentRelativePath)
+  const outputFile = join(outputRoot, wryParentRelativePath)
+
+  assert.ok(existsSync(sourceFile), `Wry keyDown source not found: ${sourceFile}`)
+
+  rmSync(outputRoot, { recursive: true, force: true })
+  mkdirSync(outputRoot, { recursive: true })
+  cpSync(sourceRoot, outputRoot, { recursive: true })
+
+  const patchedSource = patchWryKeyDownSource(readFileSync(outputFile, 'utf8'))
+  writeFileSync(outputFile, patchedSource)
+
+  return {
+    sourceRoot,
+    outputRoot,
+    sourceFile,
+    outputFile,
+    macosKeyDown: analyzeKeyDownSource(patchedSource),
+  }
+}
+
+export function diagnoseCurrentWryKeyDown() {
+  assert.ok(existsSync(cargoLockPath), `Cargo.lock not found: ${cargoLockPath}`)
+
+  const lockText = readFileSync(cargoLockPath, 'utf8')
+  const versions = {
+    tauri: readCargoLockPackageVersion(lockText, 'tauri'),
+    tao: readCargoLockPackageVersion(lockText, 'tao'),
+    wry: readCargoLockPackageVersion(lockText, 'wry'),
+  }
+
+  assert.ok(versions.wry, 'wry package version not found in Cargo.lock')
+
+  const wrySourcePath = findRegistryPackageSource('wry', versions.wry)
+  assert.ok(
+    wrySourcePath,
+    `wry ${versions.wry} source not found under ~/.cargo/registry/src; run cargo check first`,
+  )
+
+  const sourceText = readFileSync(wrySourcePath, 'utf8')
+
+  return {
+    versions,
+    wrySourcePath,
+    macosKeyDown: analyzeKeyDownSource(sourceText),
+    assessment: 'current_wry_macos_keydown_routes_to_menu_without_forwarding_guard',
+    upstreamCandidate: 'https://github.com/tauri-apps/wry/pull/1711',
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const diagnostics = diagnoseCurrentWryKeyDown()
+  if (process.argv.includes('--prepare-patch')) {
+    const packageRoot = diagnostics.wrySourcePath.slice(
+      0,
+      diagnostics.wrySourcePath.length - wryParentRelativePath.length - 1,
+    )
+    const outputArgIndex = process.argv.indexOf('--output')
+    const outputRoot = outputArgIndex === -1
+      ? join(tmpdir(), `notegen-wry-${diagnostics.versions.wry}-keydown-patched`)
+      : process.argv[outputArgIndex + 1]
+    console.log(JSON.stringify({
+      ...diagnostics,
+      preparedPatch: preparePatchedWrySource({
+        sourceRoot: packageRoot,
+        outputRoot,
+      }),
+    }, null, 2))
+  } else {
+    console.log(JSON.stringify(diagnostics, null, 2))
+  }
+}

--- a/scripts/diagnose-wry-keydown.spec.mjs
+++ b/scripts/diagnose-wry-keydown.spec.mjs
@@ -1,0 +1,116 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  analyzeKeyDownSource,
+  patchWryKeyDownSource,
+  preparePatchedWrySource,
+} from './diagnose-wry-keydown.mjs'
+
+const vulnerableSource = `
+fn key_down(&self, event: &NSEvent) {
+  let mtm = MainThreadMarker::new().unwrap();
+  let app = NSApplication::sharedApplication(mtm);
+  unsafe {
+    if let Some(menu) = app.mainMenu() {
+      menu.performKeyEquivalent(event);
+    }
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn draw(&self, _dirty_rect: NSRect) {}
+`
+
+const patchedSource = `
+fn key_down(&self, event: &NSEvent) {
+  let flags = unsafe { event.modifierFlags() };
+
+  // Note: Option (Alt) is intentionally excluded.
+  if flags.intersects(NSEventModifierFlags::Command | NSEventModifierFlags::Control) {
+    let mtm = MainThreadMarker::new().unwrap();
+    let app = NSApplication::sharedApplication(mtm);
+    unsafe {
+      if let Some(menu) = app.mainMenu() {
+        if menu.performKeyEquivalent(event) {
+          return;
+        }
+      }
+    }
+  }
+
+  unsafe {
+    self.interpretKeyEvents(&NSArray::from_slice(&[event]));
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn draw(&self, _dirty_rect: NSRect) {}
+`
+
+test('detects vulnerable Wry macOS keyDown menu sink', () => {
+  const result = analyzeKeyDownSource(vulnerableSource)
+
+  assert.equal(result.callsPerformKeyEquivalent, true)
+  assert.equal(result.checksPerformKeyEquivalentReturnValue, false)
+  assert.equal(result.hasCommandOrControlGuard, false)
+  assert.equal(result.mentionsOptionExclusion, false)
+  assert.equal(result.callsInterpretKeyEvents, false)
+})
+
+test('detects patched Wry macOS keyDown forwarding guard shape', () => {
+  const result = analyzeKeyDownSource(patchedSource)
+
+  assert.equal(result.callsPerformKeyEquivalent, true)
+  assert.equal(result.checksPerformKeyEquivalentReturnValue, true)
+  assert.equal(result.hasCommandOrControlGuard, true)
+  assert.equal(result.mentionsOptionExclusion, true)
+  assert.equal(result.callsInterpretKeyEvents, true)
+})
+
+test('patches vulnerable Wry macOS keyDown source into guarded shape', () => {
+  const source = `
+use objc2_app_kit::{NSApplication, NSEvent, NSView, NSWindow, NSWindowButton};
+use objc2_foundation::MainThreadMarker;
+use objc2_foundation::NSRect;
+
+${vulnerableSource}
+`
+
+  const patched = patchWryKeyDownSource(source)
+  const result = analyzeKeyDownSource(patched)
+
+  assert.match(patched, /NSEventModifierFlags/)
+  assert.match(patched, /NSArray/)
+  assert.equal(result.checksPerformKeyEquivalentReturnValue, true)
+  assert.equal(result.hasCommandOrControlGuard, true)
+  assert.equal(result.mentionsOptionExclusion, true)
+  assert.equal(result.callsInterpretKeyEvents, true)
+})
+
+test('prepares a patched Wry source copy', () => {
+  const root = mkdtempSync(join(tmpdir(), 'notegen-wry-keydown-test-'))
+  const sourceRoot = join(root, 'wry-source')
+  const outputRoot = join(root, 'wry-patched')
+  const parentPath = join(sourceRoot, 'src', 'wkwebview', 'class')
+  mkdirSync(parentPath, { recursive: true })
+  writeFileSync(join(sourceRoot, 'Cargo.toml'), '[package]\nname = "wry"\nversion = "0.52.1"\n')
+  writeFileSync(
+    join(parentPath, 'wry_web_view_parent.rs'),
+    [
+      'use objc2_app_kit::{NSApplication, NSEvent, NSView, NSWindow, NSWindowButton};',
+      'use objc2_foundation::MainThreadMarker;',
+      'use objc2_foundation::NSRect;',
+      vulnerableSource,
+    ].join('\n'),
+  )
+
+  const result = preparePatchedWrySource({ sourceRoot, outputRoot })
+  const patched = readFileSync(join(outputRoot, 'src', 'wkwebview', 'class', 'wry_web_view_parent.rs'), 'utf8')
+
+  assert.equal(result.outputRoot, outputRoot)
+  assert.equal(analyzeKeyDownSource(patched).hasCommandOrControlGuard, true)
+})

--- a/scripts/doubao-input-collector.mjs
+++ b/scripts/doubao-input-collector.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import http from 'node:http'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export function summarizeInputLogs(logs, metadata = {}) {
+  const eventCounts = {}
+  const targetSet = new Set()
+  const finalValues = {}
+
+  for (const log of logs) {
+    if (!log || typeof log !== 'object') continue
+    if (log.type) {
+      eventCounts[log.type] = (eventCounts[log.type] || 0) + 1
+    }
+    if (log.target) {
+      targetSet.add(log.target)
+      if (typeof log.value === 'string') {
+        finalValues[log.target] = log.value
+      }
+    }
+  }
+
+  return {
+    label: metadata.label,
+    appPath: metadata.appPath,
+    totalEvents: logs.length,
+    eventCounts,
+    targets: [...targetSet].sort(),
+    finalValues,
+  }
+}
+
+export function createLogPayload(collector) {
+  return {
+    metadata: collector.metadata,
+    logs: collector.logs,
+    summary: collector.summary(),
+  }
+}
+
+export function createInputLogCollector(metadata = {}) {
+  const logs = []
+  const collectorMetadata = {
+    label: metadata.label || 'doubao-input-debug',
+    appPath: metadata.appPath || '',
+    startedAt: metadata.startedAt || new Date().toISOString(),
+  }
+  let server
+
+  server = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1')
+
+    if (url.pathname === '/input-log') {
+      const raw = url.searchParams.get('entry') || '{}'
+      try {
+        const entry = JSON.parse(raw)
+        logs.push(entry)
+        process.stdout.write(`${JSON.stringify(entry)}\n`)
+      } catch {
+        const entry = { type: 'collector-parse-error', raw }
+        logs.push(entry)
+        process.stdout.write(`${JSON.stringify(entry)}\n`)
+      }
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-store',
+      })
+      res.end()
+      return
+    }
+
+    if (url.pathname === '/logs') {
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-store',
+      })
+      res.end(JSON.stringify(logs, null, 2))
+      return
+    }
+
+    if (url.pathname === '/summary') {
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-store',
+      })
+      res.end(JSON.stringify(summarizeInputLogs(logs, collectorMetadata), null, 2))
+      return
+    }
+
+    res.writeHead(404, { 'Access-Control-Allow-Origin': '*' })
+    res.end()
+  })
+
+  return {
+    metadata: collectorMetadata,
+    logs,
+    listen({ host = '127.0.0.1', port = 45678 } = {}) {
+      return new Promise((resolveListen, rejectListen) => {
+        server.once('error', rejectListen)
+        server.listen(port, host, () => {
+          server.off('error', rejectListen)
+          resolveListen()
+        })
+      })
+    },
+    address() {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('collector is not listening on a TCP address')
+      }
+      return address
+    },
+    close() {
+      return new Promise((resolveClose) => {
+        server.close(() => resolveClose())
+      })
+    },
+    summary() {
+      return summarizeInputLogs(logs, collectorMetadata)
+    },
+  }
+}
+
+function readArg(name, fallback) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return fallback
+  return process.argv[index + 1] ?? fallback
+}
+
+async function runCli() {
+  const port = Number(readArg('--port', '45678'))
+  const host = readArg('--host', '127.0.0.1')
+  const output = readArg('--output', 'tmp/doubao-input-logs.json')
+  const appPath = readArg('--app', '')
+  const label = readArg('--label', appPath ? 'doubao-input-app' : 'doubao-input-debug')
+  const collector = createInputLogCollector({ label, appPath: appPath ? resolve(appPath) : '' })
+
+  await collector.listen({ host, port })
+  const url = `http://${host}:${collector.address().port}`
+  console.log(`collector listening ${url}`)
+  console.log(`logs: ${url}/logs`)
+  console.log(`summary: ${url}/summary`)
+
+  if (appPath) {
+    spawn('open', ['-n', resolve(appPath)], {
+      stdio: 'ignore',
+      detached: true,
+    }).unref()
+    console.log(`opened app: ${resolve(appPath)}`)
+  }
+
+  const finish = async () => {
+    const outputPath = resolve(output)
+    mkdirSync(dirname(outputPath), { recursive: true })
+    writeFileSync(outputPath, JSON.stringify(createLogPayload(collector), null, 2))
+    console.log(`saved ${outputPath}`)
+    await collector.close()
+    process.exit(0)
+  }
+
+  process.once('SIGINT', () => void finish())
+  process.once('SIGTERM', () => void finish())
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/doubao-input-collector.spec.mjs
+++ b/scripts/doubao-input-collector.spec.mjs
@@ -1,0 +1,103 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+
+import {
+  createInputLogCollector,
+  createLogPayload,
+  summarizeInputLogs,
+} from './doubao-input-collector.mjs'
+
+test('summarizes input logs by event count, target, and final value', () => {
+  const summary = summarizeInputLogs([
+    { type: 'focus', target: 'textarea#raw-textarea', value: '' },
+    { type: 'beforeinput', target: 'textarea#raw-textarea', inputType: 'insertText', data: '测' },
+    { type: 'input', target: 'textarea#raw-textarea', inputType: 'insertText', data: '测', value: '测' },
+  ])
+
+  assert.deepEqual(summary.eventCounts, {
+    focus: 1,
+    beforeinput: 1,
+    input: 1,
+  })
+  assert.deepEqual(summary.targets, ['textarea#raw-textarea'])
+  assert.deepEqual(summary.finalValues, {
+    'textarea#raw-textarea': '测',
+  })
+})
+
+test('collector stores image-beacon input logs and exposes summary', async () => {
+  const collector = createInputLogCollector()
+  await collector.listen({ host: '127.0.0.1', port: 0 })
+
+  try {
+    const { port } = collector.address()
+    const entry = {
+      type: 'input',
+      target: 'textarea#raw-textarea',
+      value: 'voice text',
+      inputType: 'insertText',
+      data: 'voice text',
+    }
+    const response = await fetch(
+      `http://127.0.0.1:${port}/input-log?entry=${encodeURIComponent(JSON.stringify(entry))}`,
+    )
+    assert.equal(response.status, 204)
+
+    const logs = await fetch(`http://127.0.0.1:${port}/logs`).then((res) => res.json())
+    assert.deepEqual(logs, [entry])
+
+    const summary = await fetch(`http://127.0.0.1:${port}/summary`).then((res) => res.json())
+    assert.equal(summary.totalEvents, 1)
+    assert.deepEqual(summary.eventCounts, { input: 1 })
+    assert.deepEqual(summary.finalValues, {
+      'textarea#raw-textarea': 'voice text',
+    })
+  } finally {
+    await collector.close()
+  }
+})
+
+test('collector summary and saved payload include experiment metadata', async () => {
+  const collector = createInputLogCollector({
+    label: 'patched-wry',
+    appPath: '/tmp/NoteGenDoubaoDebugPatched.app',
+  })
+  await collector.listen({ host: '127.0.0.1', port: 0 })
+
+  try {
+    const { port } = collector.address()
+    await fetch(
+      `http://127.0.0.1:${port}/input-log?entry=${encodeURIComponent(JSON.stringify({
+        type: 'input',
+        target: 'textarea#raw-textarea',
+        value: 'patched voice',
+      }))}`,
+    )
+
+    const summary = await fetch(`http://127.0.0.1:${port}/summary`).then((res) => res.json())
+    assert.equal(summary.label, 'patched-wry')
+    assert.equal(summary.appPath, '/tmp/NoteGenDoubaoDebugPatched.app')
+
+    const payload = createLogPayload(collector)
+    assert.equal(payload.metadata.label, 'patched-wry')
+    assert.equal(payload.metadata.appPath, '/tmp/NoteGenDoubaoDebugPatched.app')
+    assert.equal(payload.summary.finalValues['textarea#raw-textarea'], 'patched voice')
+  } finally {
+    await collector.close()
+  }
+})
+
+test('collector module can be dynamically imported without a script argv', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['-e', 'import("./scripts/doubao-input-collector.mjs").then(() => console.log("import-ok"))'],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    },
+  )
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /import-ok/)
+})

--- a/scripts/run-doubao-input-experiment.mjs
+++ b/scripts/run-doubao-input-experiment.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import readline from 'node:readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+const defaultUnpatchedApp = 'src-tauri/target/debug/bundle/macos/NoteGenDoubaoDebug.app'
+const defaultPatchedApp = 'src-tauri/target/debug/bundle/macos/NoteGenDoubaoDebugPatched.app'
+
+function joinOutput(outputDir, fileName) {
+  return `${outputDir.replace(/\/+$/, '')}/${fileName}`
+}
+
+export function buildExperimentPlan({
+  outputDir = 'tmp',
+  unpatchedApp = defaultUnpatchedApp,
+  patchedApp = defaultPatchedApp,
+} = {}) {
+  const unpatched = joinOutput(outputDir, 'doubao-unpatched-logs.json')
+  const patched = joinOutput(outputDir, 'doubao-patched-logs.json')
+
+  return {
+    collectors: [
+      {
+        label: 'unpatched-wry',
+        app: unpatchedApp,
+        output: unpatched,
+      },
+      {
+        label: 'patched-wry',
+        app: patchedApp,
+        output: patched,
+      },
+    ],
+    compare: {
+      unpatched,
+      patched,
+    },
+  }
+}
+
+export function buildManualVoiceAttemptLog({
+  label = '',
+  time = new Date().toISOString(),
+} = {}) {
+  return {
+    type: 'manual-voice-attempt-confirmed',
+    target: 'terminal',
+    value: '',
+    label,
+    time,
+  }
+}
+
+function readArg(name, fallback) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return fallback
+  return process.argv[index + 1] ?? fallback
+}
+
+function runCommand(command, args) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+    })
+    child.once('error', rejectRun)
+    child.once('exit', (code, signal) => {
+      if (code === 0 || signal === 'SIGINT' || signal === 'SIGTERM') {
+        resolveRun()
+        return
+      }
+      rejectRun(new Error(`${command} exited with code ${code}`))
+    })
+  })
+}
+
+function startCollector(step) {
+  const child = spawn(process.execPath, [
+    'scripts/doubao-input-collector.mjs',
+    '--label',
+    step.label,
+    '--app',
+    step.app,
+    '--output',
+    step.output,
+  ], {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+  })
+
+  return child
+}
+
+async function postManualVoiceAttempt(step) {
+  const entry = buildManualVoiceAttemptLog({ label: step.label })
+  const response = await fetch(
+    `http://127.0.0.1:45678/input-log?entry=${encodeURIComponent(JSON.stringify(entry))}`,
+  )
+  if (!response.ok && response.status !== 204) {
+    throw new Error(`failed to record manual voice attempt: HTTP ${response.status}`)
+  }
+}
+
+async function stopCollector(child) {
+  if (child.exitCode !== null) return
+
+  await new Promise((resolveStop) => {
+    child.once('exit', () => resolveStop())
+    child.kill('SIGINT')
+  })
+}
+
+async function runCollectorStep(step, rl) {
+  if (!existsSync(step.app)) {
+    throw new Error(`app not found: ${step.app}`)
+  }
+
+  await mkdir(dirname(resolve(step.output)), { recursive: true })
+
+  console.log(`\n=== ${step.label} ===`)
+  console.log(`app: ${step.app}`)
+  console.log(`output: ${step.output}`)
+  console.log('在打开的窗口中点 Raw textarea，触发一次豆包语音输入。')
+
+  const child = startCollector(step)
+  try {
+    await rl.question('确认已经触发豆包语音输入后，按 Enter 保存日志并继续...')
+    await postManualVoiceAttempt(step)
+  } finally {
+    await stopCollector(child)
+  }
+}
+
+async function runCli() {
+  const plan = buildExperimentPlan({
+    outputDir: readArg('--output-dir', 'tmp'),
+    unpatchedApp: readArg('--unpatched-app', defaultUnpatchedApp),
+    patchedApp: readArg('--patched-app', defaultPatchedApp),
+  })
+  const rl = readline.createInterface({ input, output })
+
+  try {
+    for (const step of plan.collectors) {
+      await runCollectorStep(step, rl)
+    }
+
+    console.log('\n=== compare ===')
+    await runCommand(process.execPath, [
+      'scripts/compare-doubao-input-logs.mjs',
+      '--unpatched',
+      plan.compare.unpatched,
+      '--patched',
+      plan.compare.patched,
+    ])
+  } finally {
+    rl.close()
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/run-doubao-input-experiment.spec.mjs
+++ b/scripts/run-doubao-input-experiment.spec.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildExperimentPlan,
+  buildManualVoiceAttemptLog,
+} from './run-doubao-input-experiment.mjs'
+
+test('builds the default unpatched and patched Doubao experiment plan', () => {
+  const plan = buildExperimentPlan()
+
+  assert.equal(plan.collectors.length, 2)
+  assert.deepEqual(plan.collectors.map((step) => step.label), [
+    'unpatched-wry',
+    'patched-wry',
+  ])
+  assert.equal(plan.collectors[0].output, 'tmp/doubao-unpatched-logs.json')
+  assert.equal(plan.collectors[1].output, 'tmp/doubao-patched-logs.json')
+  assert.equal(plan.compare.unpatched, 'tmp/doubao-unpatched-logs.json')
+  assert.equal(plan.compare.patched, 'tmp/doubao-patched-logs.json')
+})
+
+test('allows custom output directory for experiment artifacts', () => {
+  const plan = buildExperimentPlan({ outputDir: 'tmp/custom-doubao' })
+
+  assert.equal(plan.collectors[0].output, 'tmp/custom-doubao/doubao-unpatched-logs.json')
+  assert.equal(plan.collectors[1].output, 'tmp/custom-doubao/doubao-patched-logs.json')
+  assert.equal(plan.compare.unpatched, 'tmp/custom-doubao/doubao-unpatched-logs.json')
+  assert.equal(plan.compare.patched, 'tmp/custom-doubao/doubao-patched-logs.json')
+})
+
+test('builds a manual voice attempt marker for confirmed experiment segments', () => {
+  const marker = buildManualVoiceAttemptLog({
+    label: 'patched-wry',
+    time: '2026-06-07T00:00:00.000Z',
+  })
+
+  assert.deepEqual(marker, {
+    type: 'manual-voice-attempt-confirmed',
+    target: 'terminal',
+    value: '',
+    label: 'patched-wry',
+    time: '2026-06-07T00:00:00.000Z',
+  })
+})

--- a/src/app/core/main/file/file-item.tsx
+++ b/src/app/core/main/file/file-item.tsx
@@ -32,6 +32,7 @@ import { VectorKnowledgeMenu } from "./vector-knowledge-menu";
 import { isSkillsFolder } from "@/lib/skills/utils";
 import { exportMarkdownFile, type MarkdownExportFormat } from "../editor/markdown/markdown-export";
 import { setFileManagerDragData } from "./file-dnd";
+import { preserveFileNameInputValue, sanitizeFileNameOnCommit } from "./file-name-input";
 
 type Platform = 'macos' | 'windows' | 'linux' | 'unknown'
 
@@ -48,7 +49,7 @@ function buildFileRenamePlan({
   currentPath: string
   enteredName: string
 }) {
-  const sanitizedName = enteredName.replace(/\s+/g, '_')
+  const sanitizedName = sanitizeFileNameOnCommit(enteredName)
   const needsMarkdownSuffix = originalName === '' && !sanitizedName.endsWith('.md')
   const displayName = needsMarkdownSuffix ? `${sanitizedName}.md` : sanitizedName
   const parentPath = currentPath.split('/').slice(0, -1).join('/')
@@ -71,7 +72,6 @@ function showPdfExportStartToast() {
 export function FileItem({ item, focusSidebar }: { item: DirTree; focusSidebar?: () => void }) {
   const [isEditing, setIsEditing] = useState(item.isEditing)
   const [name, setName] = useState(item.name)
-  const [isComposing, setIsComposing] = useState(false) // 追踪输入法合成状态
   const inputRef = useRef<HTMLInputElement>(null)
   const { activeFilePath, setActiveFilePath, readArticle, fileTree, setFileTree, loadFileTree, vectorIndexedFiles, checkFileVectorIndexed, cleanTabsByDeletedFile, cleanTabsByDeletedFolder } = useArticleStore()
   const setArticleState = useArticleStore.setState
@@ -135,60 +135,14 @@ export function FileItem({ item, focusSidebar }: { item: DirTree; focusSidebar?:
   // 不需要 cloneDeep，因为 getCurrentFolder 只读取数据不修改
   const currentFolder = getCurrentFolder(folderPath, fileTree)
 
-  // 优化的输入处理，支持输入法
+  // 编辑时保留原始输入，提交时再统一清洗文件名。
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.target
-    const value = input.value
-    const cursorPosition = input.selectionStart || 0
-    
-    // 如果正在使用输入法合成，不进行空格替换
-    if (isComposing) {
-      setName(value)
-      return
-    }
-    
-    // 检查是否包含空格，只有包含空格时才需要处理光标位置
-    if (value.includes(' ')) {
-      const sanitizedValue = value.replace(/\s+/g, '_')
-      setName(sanitizedValue)
-      
-      // 保持光标位置
-      requestAnimationFrame(() => {
-        if (input.selectionStart !== null) {
-          input.setSelectionRange(cursorPosition, cursorPosition)
-        }
-      })
-    } else {
-      setName(value)
-    }
-  }, [isComposing])
-
-  // 输入法合成开始
-  const handleCompositionStart = useCallback(() => {
-    setIsComposing(true)
+    setName(preserveFileNameInputValue(e.target.value))
   }, [])
 
-  // 输入法合成结束，进行空格替换
+  // 输入法合成结束后仍保留原始输入，避免语音/IME 批量提交时被即时改写。
   const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
-    setIsComposing(false)
-    const input = e.currentTarget
-    const value = input.value
-    const cursorPosition = input.selectionStart || 0
-    
-    // 只有当值包含空格时才需要替换和恢复光标位置
-    if (value.includes(' ')) {
-      const sanitizedValue = value.replace(/\s+/g, '_')
-      setName(sanitizedValue)
-      
-      // 计算新的光标位置（空格变为下划线，长度不变，所以位置保持不变）
-      requestAnimationFrame(() => {
-        if (input.selectionStart !== null) {
-          input.setSelectionRange(cursorPosition, cursorPosition)
-        }
-      })
-    } else {
-      setName(value)
-    }
+    setName(preserveFileNameInputValue(e.currentTarget.value))
   }, [])
 
   async function handleSelectFile() {
@@ -490,7 +444,7 @@ export function FileItem({ item, focusSidebar }: { item: DirTree; focusSidebar?:
       setName(finalName)
     } else {
       // 统一处理：将空格替换为下划线，确保本地和远程文件名一致
-      finalName = name.replace(/\s+/g, '_')
+      finalName = sanitizeFileNameOnCommit(name)
       setName(finalName)
     }
   
@@ -922,7 +876,6 @@ export function FileItem({ item, focusSidebar }: { item: DirTree; focusSidebar?:
                   value={name}
                   onBlur={handleRename}
                   onChange={handleInputChange}
-                  onCompositionStart={handleCompositionStart}
                   onCompositionEnd={handleCompositionEnd}
                   onKeyDown={(e) => {
                     // 阻止删除快捷键冒泡到全局快捷键处理器

--- a/src/app/core/main/file/file-name-input.js
+++ b/src/app/core/main/file/file-name-input.js
@@ -1,0 +1,7 @@
+export function preserveFileNameInputValue(value) {
+  return value
+}
+
+export function sanitizeFileNameOnCommit(value) {
+  return value.replace(/\s+/g, '_')
+}

--- a/src/app/core/main/file/file-name-input.spec.mjs
+++ b/src/app/core/main/file/file-name-input.spec.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  preserveFileNameInputValue,
+  sanitizeFileNameOnCommit,
+} from './file-name-input.js'
+
+test('preserves whitespace while editing file names', () => {
+  assert.equal(preserveFileNameInputValue('voice probe'), 'voice probe')
+  assert.equal(preserveFileNameInputValue('voice   probe'), 'voice   probe')
+})
+
+test('replaces whitespace only when committing file names', () => {
+  assert.equal(sanitizeFileNameOnCommit('voice probe'), 'voice_probe')
+  assert.equal(sanitizeFileNameOnCommit('voice   probe'), 'voice_probe')
+})

--- a/src/app/core/main/file/folder-item/index.tsx
+++ b/src/app/core/main/file/folder-item/index.tsx
@@ -35,11 +35,11 @@ import {
   moveFileManagerEntry,
   setFileManagerDragData,
 } from '../file-dnd'
+import { preserveFileNameInputValue, sanitizeFileNameOnCommit } from '../file-name-input'
 
 export function FolderItem({ item, focusSidebar }: { item: DirTree; focusSidebar?: () => void }) {
   const [isEditing, setIsEditing] = useState(item.isEditing)
   const [name, setName] = useState(item.name)
-  const [isComposing, setIsComposing] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const dragExpandTimeoutRef = useRef<number | null>(null)
@@ -329,66 +329,20 @@ export function FolderItem({ item, focusSidebar }: { item: DirTree; focusSidebar
     }
   }
 
-  // 优化的输入处理，支持输入法
+  // 编辑时保留原始输入，提交时再统一清洗文件夹名。
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.target
-    const value = input.value
-    const cursorPosition = input.selectionStart || 0
-    
-    // 如果正在使用输入法合成，不进行空格替换
-    if (isComposing) {
-      setName(value)
-      return
-    }
-    
-    // 检查是否包含空格，只有包含空格时才需要处理光标位置
-    if (value.includes(' ')) {
-      const sanitizedValue = value.replace(/\s+/g, '_')
-      setName(sanitizedValue)
-      
-      // 保持光标位置
-      requestAnimationFrame(() => {
-        if (input.selectionStart !== null) {
-          input.setSelectionRange(cursorPosition, cursorPosition)
-        }
-      })
-    } else {
-      setName(value)
-    }
-  }, [isComposing])
-
-  // 输入法合成开始
-  const handleCompositionStart = useCallback(() => {
-    setIsComposing(true)
+    setName(preserveFileNameInputValue(e.target.value))
   }, [])
 
-  // 输入法合成结束，进行空格替换
+  // 输入法合成结束后仍保留原始输入，避免语音/IME 批量提交时被即时改写。
   const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
-    setIsComposing(false)
-    const input = e.currentTarget
-    const value = input.value
-    const cursorPosition = input.selectionStart || 0
-    
-    // 只有当值包含空格时才需要替换和恢复光标位置
-    if (value.includes(' ')) {
-      const sanitizedValue = value.replace(/\s+/g, '_')
-      setName(sanitizedValue)
-      
-      // 计算新的光标位置（空格变为下划线，长度不变，所以位置保持不变）
-      requestAnimationFrame(() => {
-        if (input.selectionStart !== null) {
-          input.setSelectionRange(cursorPosition, cursorPosition)
-        }
-      })
-    } else {
-      setName(value)
-    }
+    setName(preserveFileNameInputValue(e.currentTarget.value))
   }, [])
 
   // 创建或修改文件夹名称
   async function handleRename() {
     // 统一处理：将空格替换为下划线，确保本地和远程文件名一致
-    const sanitizedName = name.replace(/\s+/g, '_')
+    const sanitizedName = sanitizeFileNameOnCommit(name)
     setName(sanitizedName)
 
     // 获取工作区路径信息
@@ -797,7 +751,6 @@ export function FolderItem({ item, focusSidebar }: { item: DirTree; focusSidebar
                     value={name}
                     onBlur={handleRename}
                     onChange={handleInputChange}
-                    onCompositionStart={handleCompositionStart}
                     onCompositionEnd={handleCompositionEnd}
                     onKeyDown={(e) => {
                       // 阻止删除快捷键冒泡到全局快捷键处理器

--- a/src/app/input-debug/page.tsx
+++ b/src/app/input-debug/page.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type InputLog = {
+  id: number
+  time: string
+  type: string
+  target: string
+  inputType?: string
+  data?: string
+  isComposing?: boolean
+  value?: string
+  controlledValue: string
+}
+
+const eventTypes = [
+  'focus',
+  'beforeinput',
+  'input',
+  'change',
+  'compositionstart',
+  'compositionupdate',
+  'compositionend',
+  'keydown',
+  'keyup',
+  'paste',
+]
+
+function describeTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return 'unknown'
+  }
+
+  const id = target.id ? `#${target.id}` : ''
+  const name = target.getAttribute('name')
+  const namePart = name ? `[name="${name}"]` : ''
+  return `${target.tagName.toLowerCase()}${id}${namePart}`
+}
+
+function readTargetValue(target: EventTarget | null) {
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    return target.value
+  }
+
+  if (target instanceof HTMLElement && target.isContentEditable) {
+    return target.textContent ?? ''
+  }
+
+  return undefined
+}
+
+function readEventData(event: Event) {
+  if (event instanceof InputEvent) {
+    return {
+      data: event.data ?? undefined,
+      inputType: event.inputType || undefined,
+      isComposing: event.isComposing,
+    }
+  }
+
+  if (event instanceof CompositionEvent) {
+    return {
+      data: event.data || undefined,
+    }
+  }
+
+  if (event instanceof KeyboardEvent) {
+    return {
+      data: event.key,
+      isComposing: event.isComposing,
+    }
+  }
+
+  return {}
+}
+
+export default function InputDebugPage() {
+  const [controlledValue, setControlledValue] = useState('')
+  const [logs, setLogs] = useState<InputLog[]>([])
+  const nextIdRef = useRef(1)
+  const controlledValueRef = useRef(controlledValue)
+
+  useEffect(() => {
+    controlledValueRef.current = controlledValue
+  }, [controlledValue])
+
+  const appendLog = useCallback((event: Event) => {
+    const data = readEventData(event)
+    const value = readTargetValue(event.target)
+    const nextLog: InputLog = {
+      id: nextIdRef.current,
+      time: new Date().toISOString(),
+      type: event.type,
+      target: describeTarget(event.target),
+      value,
+      controlledValue: controlledValueRef.current,
+      ...data,
+    }
+    nextIdRef.current += 1
+
+    setLogs((current) => [nextLog, ...current].slice(0, 200))
+  }, [])
+
+  useEffect(() => {
+    const handler = (event: Event) => appendLog(event)
+
+    for (const type of eventTypes) {
+      document.addEventListener(type, handler, true)
+    }
+
+    return () => {
+      for (const type of eventTypes) {
+        document.removeEventListener(type, handler, true)
+      }
+    }
+  }, [appendLog])
+
+  const clear = useCallback(() => {
+    setControlledValue('')
+    setLogs([])
+    nextIdRef.current = 1
+    const raw = document.getElementById('doubao-raw-textarea')
+    if (raw instanceof HTMLTextAreaElement) {
+      raw.value = ''
+    }
+    const plainInput = document.getElementById('doubao-plain-input')
+    if (plainInput instanceof HTMLInputElement) {
+      plainInput.value = ''
+    }
+    const editable = document.getElementById('doubao-contenteditable')
+    if (editable instanceof HTMLElement) {
+      editable.textContent = ''
+    }
+  }, [])
+
+  const copyLogs = useCallback(async () => {
+    await navigator.clipboard.writeText(JSON.stringify(logs.slice().reverse(), null, 2))
+  }, [logs])
+
+  return (
+    <main className="min-h-screen bg-background p-6 text-foreground">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4">
+        <header className="flex flex-wrap items-center justify-between gap-3 border-b pb-4">
+          <div>
+            <h1 className="text-xl font-semibold">Input Event Debug</h1>
+            <p className="text-sm text-muted-foreground">Tauri/WKWebView text receiver probe</p>
+          </div>
+          <div className="flex gap-2">
+            <button className="rounded border px-3 py-2 text-sm" onClick={clear} type="button">
+              Clear
+            </button>
+            <button className="rounded border px-3 py-2 text-sm" onClick={copyLogs} type="button">
+              Copy logs
+            </button>
+          </div>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Raw textarea
+            <textarea
+              className="min-h-32 rounded border bg-transparent p-3 font-normal"
+              id="doubao-raw-textarea"
+              name="raw-textarea"
+              placeholder="raw textarea"
+              rows={6}
+            />
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            React controlled textarea
+            <textarea
+              className="min-h-32 rounded border bg-transparent p-3 font-normal"
+              id="doubao-controlled-textarea"
+              name="controlled-textarea"
+              onChange={(event) => setControlledValue(event.target.value)}
+              placeholder="controlled textarea"
+              rows={6}
+              value={controlledValue}
+            />
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Plain input
+            <input
+              className="rounded border bg-transparent p-3 font-normal"
+              id="doubao-plain-input"
+              name="plain-input"
+              placeholder="plain input"
+            />
+          </label>
+
+          <div className="flex flex-col gap-2 text-sm font-medium">
+            Content editable
+            <div
+              className="min-h-24 rounded border bg-transparent p-3 font-normal"
+              contentEditable
+              id="doubao-contenteditable"
+              role="textbox"
+              suppressContentEditableWarning
+            />
+          </div>
+        </section>
+
+        <section className="grid gap-3">
+          <h2 className="text-base font-semibold">Event log</h2>
+          <div className="max-h-[46vh] overflow-auto rounded border">
+            <table className="w-full table-fixed text-left text-xs">
+              <thead className="sticky top-0 bg-background">
+                <tr className="border-b">
+                  <th className="w-20 p-2">#</th>
+                  <th className="w-36 p-2">event</th>
+                  <th className="w-48 p-2">target</th>
+                  <th className="w-40 p-2">inputType/key</th>
+                  <th className="p-2">value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map((log) => (
+                  <tr className="border-b align-top" key={log.id}>
+                    <td className="p-2 text-muted-foreground">{log.id}</td>
+                    <td className="p-2">{log.type}</td>
+                    <td className="p-2">{log.target}</td>
+                    <td className="p-2">
+                      {log.inputType || log.data || ''}
+                      {log.isComposing ? ' composing' : ''}
+                    </td>
+                    <td className="break-words p-2">{log.value ?? log.controlledValue}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- Preserve raw file and folder rename input while editing, then sanitize whitespace on commit.
- Add macOS Doubao voice input diagnostic probes and collector scripts.
- Add Wry keyDown diagnostic tooling and comparison helpers for Tauri/WKWebView input event investigation.

## Bug Fix Context

This addresses the NoteGen-side filename input mutation issue found while investigating macOS Doubao voice input. The remaining Doubao failure was localized with manual evidence to Tauri/WKWebView native input event bridging: the same pure HTML probe receives composition/input events in a browser, while the Tauri/WKWebView probe receives only focus events.

## Test Plan

- [x] `node --test scripts/run-doubao-input-experiment.spec.mjs scripts/compare-doubao-input-logs.spec.mjs scripts/doubao-input-collector.spec.mjs scripts/diagnose-wry-keydown.spec.mjs src/app/core/main/file/file-name-input.spec.mjs public/doubao-input-debug.spec.mjs`
- [x] `pnpm exec tsc --noEmit --pretty false`
- [x] `git diff --check`
