### PR TITLE
feat: 支持导入 Notion 导出的 zip 笔记

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3453,6 +3453,7 @@
         "processingVectors": "Processing Vector Data",
         "calculateVectors": "Knowledge Base Calculation (Full)",
         "importMarkdown": "Import Notes",
+        "importNotion": "Import Notion (.zip)",
         "importing": "Importing...",
         "importSuccess": "Import Successful",
         "importSuccessDesc": "Successfully imported {count} files",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -3350,6 +3350,7 @@
         "processingVectors": "ベクトルデータ処理中",
         "calculateVectors": "知識庫計算（全量）",
         "importMarkdown": "ノートをインポート",
+        "importNotion": "Notion をインポート（.zip）",
         "importing": "インポート中...",
         "importSuccess": "インポート成功",
         "importSuccessDesc": "{count} 個のファイルをインポートしました",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -3333,6 +3333,7 @@
         "processingVectors": "Processando Dados Vetoriais",
         "calculateVectors": "Cálculo da Base de Conhecimento (Completo)",
         "importMarkdown": "Importar notas",
+        "importNotion": "Importar Notion (.zip)",
         "importing": "Importando...",
         "importSuccess": "Importação Bem-sucedida",
         "importSuccessDesc": "Importados {count} arquivos com sucesso",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -3340,6 +3340,7 @@
         "processingVectors": "正在處理向量數據",
         "calculateVectors": "知識庫計算（全量）",
         "importMarkdown": "匯入筆記",
+        "importNotion": "匯入 Notion（.zip）",
         "importing": "正在匯入...",
         "importSuccess": "匯入成功",
         "importSuccessDesc": "成功匯入 {count} 個文件",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -3473,6 +3473,7 @@
         "processingVectors": "正在处理向量数据",
         "calculateVectors": "知识库计算（全量）",
         "importMarkdown": "导入笔记",
+        "importNotion": "导入 Notion（.zip）",
         "importing": "正在导入...",
         "importSuccess": "导入成功",
         "importSuccessDesc": "成功导入 {count} 个文件",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod ios_ocr;
 mod mcp;
 mod mcp_runtime;
 mod mobile_system_bars;
+mod notion_import;
 mod ocr_packages;
 mod printing;
 mod remote_skills;
@@ -33,6 +34,7 @@ use mcp::{
 use mcp_runtime::{
     cancel_mcp_runtime_install, inspect_mcp_runtime, install_mcp_runtime, RuntimeInstallManager,
 };
+use notion_import::import_notion_zip;
 use ocr_packages::{list_ocr_providers, run_ocr_provider};
 use remote_skills::{
     cancel_remote_skill_download, inspect_remote_skill, install_remote_skill, search_remote_skills,
@@ -90,6 +92,7 @@ pub fn run() {
             database_recovery::delete_local_database,
             import_skill,
             import_skill_zip,
+            import_notion_zip,
             validate_skill_package,
             install_skill_package,
             uninstall_skill,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,6 +15,7 @@ mod fuzzy_search;
 mod keywords;
 mod mcp;
 mod mcp_runtime;
+mod notion_import;
 mod ocr_packages;
 mod printing;
 mod remote_skills;
@@ -41,6 +42,7 @@ use mcp::{
 use mcp_runtime::{
     cancel_mcp_runtime_install, inspect_mcp_runtime, install_mcp_runtime, RuntimeInstallManager,
 };
+use notion_import::import_notion_zip;
 use ocr_packages::{list_ocr_providers, run_ocr_provider};
 use remote_skills::{
     cancel_remote_skill_download, inspect_remote_skill, install_remote_skill, search_remote_skills,
@@ -99,6 +101,7 @@ fn main() {
             database_recovery::delete_local_database,
             import_skill,
             import_skill_zip,
+            import_notion_zip,
             validate_skill_package,
             install_skill_package,
             uninstall_skill,

--- a/src-tauri/src/notion_import.rs
+++ b/src-tauri/src/notion_import.rs
@@ -1,0 +1,288 @@
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
+use std::collections::HashSet;
+use std::fs;
+use std::io::{Cursor, Read, Seek};
+use std::path::{Path, PathBuf};
+use zip::ZipArchive;
+
+const MAX_NESTED_DEPTH: u8 = 3;
+const MAX_EXTRACTED_BYTES: u64 = 1024 * 1024 * 1024;
+const NOTION_ID_LEN: usize = 32;
+
+const URL_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'%')
+    .add(b'?')
+    .add(b'#')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'(')
+    .add(b')');
+
+fn is_markdown(name: &str) -> bool {
+    name.to_ascii_lowercase().ends_with(".md")
+}
+
+fn is_image(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg"]
+        .iter()
+        .any(|ext| lower.ends_with(ext))
+}
+
+/// Notion appends a 32-char hex block id to every exported page and folder,
+/// e.g. "My Page 39d2b6745dc680a88669df442674befe".
+fn strip_notion_id(name: &str) -> &str {
+    if name.len() <= NOTION_ID_LEN + 1 {
+        return name;
+    }
+    let split_index = name.len() - NOTION_ID_LEN;
+    if !name.is_char_boundary(split_index) {
+        return name;
+    }
+    let (head, tail) = name.split_at(split_index);
+    if head.ends_with(' ') && tail.chars().all(|c| c.is_ascii_hexdigit()) {
+        let cleaned = head.trim_end();
+        if !cleaned.is_empty() {
+            return cleaned;
+        }
+    }
+    name
+}
+
+fn clean_segment(segment: &str, is_last: bool) -> String {
+    if is_last {
+        if let Some(dot_index) = segment.rfind('.') {
+            if dot_index > 0 {
+                let (stem, extension) = segment.split_at(dot_index);
+                return format!("{}{}", strip_notion_id(stem), extension);
+            }
+        }
+    }
+    strip_notion_id(segment).to_string()
+}
+
+fn clean_relative_path(path: &Path) -> Option<PathBuf> {
+    let segments: Vec<String> = path
+        .iter()
+        .map(|segment| segment.to_string_lossy().into_owned())
+        .collect();
+    if segments.is_empty() {
+        return None;
+    }
+    let last_index = segments.len() - 1;
+    let mut cleaned = PathBuf::new();
+    for (index, segment) in segments.iter().enumerate() {
+        cleaned.push(clean_segment(segment, index == last_index));
+    }
+    Some(cleaned)
+}
+
+fn rewrite_url(url: &str) -> String {
+    let trimmed = url.trim();
+    if trimmed.is_empty()
+        || trimmed.starts_with('#')
+        || trimmed.contains("://")
+        || trimmed.starts_with("mailto:")
+        || trimmed.starts_with("data:")
+    {
+        return url.to_string();
+    }
+
+    let segments: Vec<&str> = trimmed.split('/').collect();
+    let last_index = segments.len() - 1;
+    let rewritten: Vec<String> = segments
+        .iter()
+        .enumerate()
+        .map(|(index, segment)| {
+            let decoded = percent_decode_str(segment).decode_utf8_lossy();
+            let cleaned = clean_segment(&decoded, index == last_index);
+            utf8_percent_encode(&cleaned, URL_ENCODE_SET).to_string()
+        })
+        .collect();
+    rewritten.join("/")
+}
+
+/// Rewrites `](path)` style links so they keep pointing at the renamed files.
+fn rewrite_markdown_links(content: &str) -> String {
+    let bytes = content.as_bytes();
+    let mut out = String::with_capacity(content.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b']' && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
+            let start = i + 2;
+            let mut depth = 1usize;
+            let mut j = start;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    b'\n' => break,
+                    _ => {}
+                }
+                j += 1;
+            }
+            if depth == 0 && j < bytes.len() && content.is_char_boundary(start) {
+                out.push_str("](");
+                out.push_str(&rewrite_url(&content[start..j]));
+                out.push(')');
+                i = j + 1;
+                continue;
+            }
+        }
+        let ch = content[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+struct ExtractedFile {
+    relative_path: PathBuf,
+    contents: Vec<u8>,
+}
+
+fn collect_entries<R: Read + Seek>(
+    archive: &mut ZipArchive<R>,
+    files: &mut Vec<ExtractedFile>,
+    extracted_bytes: &mut u64,
+    depth: u8,
+) -> Result<(), String> {
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| format!("Failed to read zip entry: {error}"))?;
+        if entry.is_dir() {
+            continue;
+        }
+        let Some(entry_path) = entry.enclosed_name() else {
+            continue;
+        };
+        let entry_path = entry_path.to_path_buf();
+        let file_name = entry_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if file_name.starts_with('.') {
+            continue;
+        }
+
+        let is_nested_zip = file_name.to_ascii_lowercase().ends_with(".zip");
+        if !is_nested_zip && !is_markdown(&file_name) && !is_image(&file_name) {
+            continue;
+        }
+
+        *extracted_bytes = extracted_bytes.saturating_add(entry.size());
+        if *extracted_bytes > MAX_EXTRACTED_BYTES {
+            return Err("Zip archive exceeds the 1 GB extraction limit".to_string());
+        }
+
+        let mut contents = Vec::with_capacity(entry.size() as usize);
+        entry
+            .read_to_end(&mut contents)
+            .map_err(|error| format!("Failed to extract zip entry: {error}"))?;
+
+        if is_nested_zip {
+            if depth + 1 < MAX_NESTED_DEPTH {
+                let mut nested = ZipArchive::new(Cursor::new(contents))
+                    .map_err(|error| format!("Failed to read nested zip archive: {error}"))?;
+                collect_entries(&mut nested, files, extracted_bytes, depth + 1)?;
+            }
+            continue;
+        }
+
+        let Some(relative_path) = clean_relative_path(&entry_path) else {
+            continue;
+        };
+        if is_markdown(&file_name) {
+            let text = String::from_utf8_lossy(&contents);
+            contents = rewrite_markdown_links(&text).into_bytes();
+        }
+        files.push(ExtractedFile {
+            relative_path,
+            contents,
+        });
+    }
+    Ok(())
+}
+
+fn import_notion_zip_inner(zip_path: &str, target_dir: &str) -> Result<usize, String> {
+    let file =
+        fs::File::open(zip_path).map_err(|error| format!("Failed to open zip file: {error}"))?;
+    let mut archive =
+        ZipArchive::new(file).map_err(|error| format!("Failed to read zip archive: {error}"))?;
+
+    let mut files = Vec::new();
+    let mut extracted_bytes = 0u64;
+    collect_entries(&mut archive, &mut files, &mut extracted_bytes, 0)?;
+
+    let target_root = Path::new(target_dir);
+    let mut written_paths: HashSet<PathBuf> = HashSet::new();
+    let mut imported_count = 0usize;
+
+    for file in files {
+        // Two different pages can clean to the same name; keep the first one.
+        if !written_paths.insert(file.relative_path.clone()) {
+            continue;
+        }
+        let target_path = target_root.join(&file.relative_path);
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("Failed to create directory: {error}"))?;
+        }
+        fs::write(&target_path, &file.contents)
+            .map_err(|error| format!("Failed to write file: {error}"))?;
+        imported_count += 1;
+    }
+
+    Ok(imported_count)
+}
+
+#[tauri::command]
+pub async fn import_notion_zip(zip_path: String, target_dir: String) -> Result<usize, String> {
+    tauri::async_runtime::spawn_blocking(move || import_notion_zip_inner(&zip_path, &target_dir))
+        .await
+        .map_err(|error| format!("Notion import task failed: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_notion_id_from_names() {
+        assert_eq!(
+            strip_notion_id("AI 2cc2b6745dc680849b5ef051ef87c612"),
+            "AI"
+        );
+        assert_eq!(strip_notion_id("plain name"), "plain name");
+        assert_eq!(
+            clean_segment("RAG 39d2b6745dc68012930afe9bc14d27eb.md", true),
+            "RAG.md"
+        );
+    }
+
+    #[test]
+    fn rewrites_encoded_links() {
+        let input = "[RAG](AI/RAG%2039d2b6745dc68012930afe9bc14d27eb.md) and [web](https://example.com/a%20b)";
+        let output = rewrite_markdown_links(input);
+        assert_eq!(
+            output,
+            "[RAG](AI/RAG.md) and [web](https://example.com/a%20b)"
+        );
+    }
+
+    #[test]
+    fn keeps_balanced_parens_in_links() {
+        let input = "[a](%E8%8F%9C%20(1)/img%202cd2b6745dc681d2b2dccf7e9d330c0e.png)";
+        let output = rewrite_markdown_links(input);
+        assert_eq!(output, "[a](%E8%8F%9C%20%281%29/img.png)");
+    }
+}
+

--- a/src/app/core/main/file/file-actions.tsx
+++ b/src/app/core/main/file/file-actions.tsx
@@ -12,7 +12,7 @@ import { useMarkdownImport } from './use-markdown-import'
 export function FileActions() {
   const { newFolder, newFile, loadFileTree, loadRemoteSyncFiles, fileTreeLoading } = useArticleStore()
   const t = useTranslations('article.file.toolbar')
-  const { isImporting, importMarkdown } = useMarkdownImport()
+  const { isImporting, importMarkdown, importNotionZip } = useMarkdownImport()
   const [isRefreshing, setIsRefreshing] = useState(false)
 
   const debounceNewFile = debounce(newFile, 200)
@@ -54,6 +54,7 @@ export function FileActions() {
       <FileMoreMenu
         isImporting={isImporting}
         onImportMarkdown={() => void importMarkdown()}
+        onImportNotion={() => void importNotionZip()}
       />
     </div>
   )

--- a/src/app/core/main/file/file-more-menu.tsx
+++ b/src/app/core/main/file/file-more-menu.tsx
@@ -13,6 +13,7 @@ import {
   Download,
   EllipsisVertical,
   Eye,
+  FileArchive,
   FolderInput,
   LoaderCircle,
   PackageOpen,
@@ -44,9 +45,10 @@ import { isSyncConfigured } from '@/lib/sync/sync-manager'
 type FileMoreMenuProps = {
   isImporting: boolean
   onImportMarkdown: () => void
+  onImportNotion: () => void
 }
 
-export function FileMoreMenu({ isImporting, onImportMarkdown }: FileMoreMenuProps) {
+export function FileMoreMenu({ isImporting, onImportMarkdown, onImportNotion }: FileMoreMenuProps) {
   const t = useTranslations('article.file.cloudLibrary')
   const tToolbar = useTranslations('article.file.toolbar')
   const {
@@ -380,6 +382,10 @@ export function FileMoreMenu({ isImporting, onImportMarkdown }: FileMoreMenuProp
         <DropdownMenuItem onSelect={onImportMarkdown}>
           <FolderInput className="mr-2 size-4" />
           {isImporting ? tToolbar('importing') : tToolbar('importMarkdown')}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onImportNotion}>
+          <FileArchive className="mr-2 size-4" />
+          {isImporting ? tToolbar('importing') : tToolbar('importNotion')}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/app/core/main/file/use-markdown-import.ts
+++ b/src/app/core/main/file/use-markdown-import.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react'
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { copyFile, exists, mkdir, readDir } from '@tauri-apps/plugin-fs'
 import { appDataDir, join } from '@tauri-apps/api/path'
+import { invoke } from '@tauri-apps/api/core'
 import { useTranslations } from 'next-intl'
 import { toast } from '@/hooks/use-toast'
 import { getWorkspacePath } from '@/lib/workspace'
@@ -98,5 +99,48 @@ export function useMarkdownImport() {
     }
   }, [isImporting, loadFileTree, t])
 
-  return { isImporting, importMarkdown }
+  const importNotionZip = useCallback(async () => {
+    if (isImporting) {
+      return
+    }
+
+    setIsImporting(true)
+    try {
+      const selectedPath = await openDialog({
+        multiple: false,
+        filters: [{ name: 'Notion Export', extensions: ['zip'] }],
+        title: t('importNotion'),
+      })
+
+      if (!selectedPath || Array.isArray(selectedPath)) {
+        return
+      }
+
+      const workspace = await getWorkspacePath()
+      const targetDir = workspace.isCustom
+        ? workspace.path
+        : await join(await appDataDir(), 'article')
+      const copiedCount = await invoke<number>('import_notion_zip', {
+        zipPath: selectedPath,
+        targetDir,
+      })
+
+      await loadFileTree()
+      toast({
+        title: t('importSuccess'),
+        description: t('importSuccessDesc', { count: copiedCount }),
+      })
+    } catch (error) {
+      console.error('Import notion zip error:', error)
+      toast({
+        title: t('importError'),
+        description: String(error),
+        variant: 'destructive',
+      })
+    } finally {
+      setIsImporting(false)
+    }
+  }, [isImporting, loadFileTree, t])
+
+  return { isImporting, importMarkdown, importNotionZip }
 }

--- a/src/lib/markdown-image-path.ts
+++ b/src/lib/markdown-image-path.ts
@@ -34,6 +34,19 @@ function getMarkdownDirSegments(markdownPath: string): string[] {
   return segments.slice(0, -1)
 }
 
+// Markdown 链接中的路径通常经过 URL 编码（如空格为 %20），解析为磁盘路径时需解码
+function decodePathSegment(segment: string): string {
+  if (!segment.includes('%')) {
+    return segment
+  }
+
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return segment
+  }
+}
+
 export function resolveImagePathFromMarkdown(markdownPath: string, imagePath: string): string {
   const markdownDirSegments = getMarkdownDirSegments(markdownPath)
   const imageSegments = imagePath
@@ -42,6 +55,7 @@ export function resolveImagePathFromMarkdown(markdownPath: string, imagePath: st
     .replace(/\/+/g, '/')
     .split('/')
     .filter(Boolean)
+    .map(decodePathSegment)
 
   const resolvedSegments = [...markdownDirSegments]
 


### PR DESCRIPTION
## 功能说明

在左栏"更多"菜单的"导入笔记"下方新增"导入 Notion（.zip）"入口，选择 Notion 导出的 zip 文件即可导入。导入位置与"导入笔记"一致（自定义工作区根目录或 `appData/article`，保留目录结构）。

## 实现

- **Rust**：新增 `import_notion_zip` 命令（`src-tauri/src/notion_import.rs`），在后台线程解压：
  - 支持 Notion 导出的嵌套分卷 zip（外层 zip 内含 `ExportBlock-xxx-Part-N.zip`）
  - 仅提取 Markdown 与图片文件，与现有"导入笔记"行为一致
  - 去除文件/文件夹名末尾的 32 位 Notion 块 ID（如 `RAG 39d2b6745dc68012930afe9bc14d27eb.md` → `RAG.md`）
  - 重写 Markdown 内的百分号编码相对链接，使其继续指向重命名后的文件；外部链接（http/mailto/锚点等）保持不变
  - 含 1GB 解压上限（防 zip 炸弹）与 `enclosed_name` 路径防护（防 zip-slip）
- **前端**：`useMarkdownImport` 新增 `importNotionZip`，复用现有导入的进度/成功/失败 toast；菜单项与五种语言文案（en/zh/zh-TW/ja/pt-BR）
- 命令已同时注册于桌面端（`main.rs`）与移动端（`lib.rs`）

## 测试

- 3 个 Rust 单元测试（ID 剥离、链接重写、括号平衡链接）
- 使用真实 Notion 导出 zip 做了端到端验证：中文/emoji 文件名、多级目录、内部链接改写均正确
- `cargo check` / `tsc --noEmit` / eslint 通过
