### PR TITLE
feat: 粘贴链接支持转为 Notion 风格书签卡片

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3931,6 +3931,12 @@
       "line": "Quoted from {fileName} line {line}",
       "lines": "Quoted from {fileName} lines {start}-{end}"
     },
+    "bookmark": {
+      "loading": "Fetching link info: {url}",
+      "fetchFailed": "Failed to fetch link info. Click refresh to retry.",
+      "refresh": "Refresh",
+      "toLink": "Convert to link"
+    },
     "bubbleMenu": {
       "ai": "AI",
       "polish": "Polish",
@@ -3949,6 +3955,7 @@
       "quoteToChat": "Quote to Chat",
       "link": "Link",
       "openLink": "Open link",
+      "pasteAsCard": "Paste as card",
       "linkPlaceholder": "Enter link URL",
       "confirm": "Confirm",
       "cancel": "Cancel",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -3820,6 +3820,12 @@
       "line": "{fileName}の{line}行目から引用",
       "lines": "{fileName}の{start}-{end}行目から引用"
     },
+    "bookmark": {
+      "loading": "リンク情報を取得中：{url}",
+      "fetchFailed": "リンク情報の取得に失敗しました。更新して再試行できます",
+      "refresh": "更新",
+      "toLink": "リンクに変換"
+    },
     "bubbleMenu": {
       "ai": "AI",
       "polish": "添削",
@@ -3838,6 +3844,7 @@
       "quoteToChat": "チャットに引用",
       "link": "リンク",
       "openLink": "リンクを開く",
+      "pasteAsCard": "カードとして貼り付け",
       "linkPlaceholder": "リンクURLを入力",
       "confirm": "確認",
       "cancel": "キャンセル",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -3770,6 +3770,12 @@
       "enhance": "Aprimorar busca",
       "searching": "Buscando arquivos relacionados..."
     },
+    "bookmark": {
+      "loading": "Obtendo informações do link: {url}",
+      "fetchFailed": "Falha ao obter informações do link. Clique em atualizar para tentar novamente.",
+      "refresh": "Atualizar",
+      "toLink": "Converter em link"
+    },
     "bubbleMenu": {
       "ai": "IA",
       "polish": "Polir",
@@ -3788,6 +3794,7 @@
       "quoteToChat": "Citar no Chat",
       "link": "Link",
       "openLink": "Abrir link",
+      "pasteAsCard": "Colar como cartão",
       "linkPlaceholder": "Digite a URL do link",
       "confirm": "Confirmar",
       "cancel": "Cancelar",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -3810,6 +3810,12 @@
       "line": "引用自 {fileName} 第 {line} 行",
       "lines": "引用自 {fileName} 第 {start}-{end} 行"
     },
+    "bookmark": {
+      "loading": "正在取得連結資訊：{url}",
+      "fetchFailed": "取得連結資訊失敗，可點擊重新整理重試",
+      "refresh": "重新整理",
+      "toLink": "轉為一般連結"
+    },
     "bubbleMenu": {
       "ai": "AI",
       "polish": "潤色",
@@ -3828,6 +3834,7 @@
       "quoteToChat": "引用到對話",
       "link": "連結",
       "openLink": "打開連結",
+      "pasteAsCard": "貼上為卡片",
       "linkPlaceholder": "輸入連結地址",
       "confirm": "確認",
       "cancel": "取消",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -3951,6 +3951,12 @@
       "line": "引用自 {fileName} 第 {line} 行",
       "lines": "引用自 {fileName} 第 {start}-{end} 行"
     },
+    "bookmark": {
+      "loading": "正在获取链接信息：{url}",
+      "fetchFailed": "获取链接信息失败，可点击刷新重试",
+      "refresh": "刷新",
+      "toLink": "转为普通链接"
+    },
     "bubbleMenu": {
       "ai": "AI",
       "polish": "润色",
@@ -3969,6 +3975,7 @@
       "quoteToChat": "引用到对话",
       "link": "链接",
       "openLink": "打开链接",
+      "pasteAsCard": "粘贴为卡片",
       "linkPlaceholder": "输入链接地址",
       "confirm": "确认",
       "cancel": "取消",

--- a/src/app/core/main/editor/markdown/bookmark-extension.tsx
+++ b/src/app/core/main/editor/markdown/bookmark-extension.tsx
@@ -1,0 +1,349 @@
+'use client'
+
+import { getMarkRange, Node, mergeAttributes } from '@tiptap/core'
+import type { Range } from '@tiptap/core'
+import { ReactNodeViewRenderer, NodeViewWrapper, ReactNodeViewProps } from '@tiptap/react'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { Globe, Link2, LoaderCircle, RefreshCw } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { capturePublicWebPage } from '@/lib/web-capture/service'
+import { cn } from '@/lib/utils'
+
+export interface BookmarkAttrs {
+  url: string
+  title: string
+  description: string
+  icon: string
+  cover: string
+  siteName: string
+  status: 'loading' | 'ready' | 'error'
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    bookmarkCard: {
+      insertBookmarkCard: (url: string) => ReturnType
+      convertLinkToBookmark: () => ReturnType
+    }
+  }
+}
+
+function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return url
+  }
+}
+
+function getFaviconUrl(url: string): string {
+  try {
+    return `${new URL(url).origin}/favicon.ico`
+  } catch {
+    return ''
+  }
+}
+
+function parseBookmarkPayload(raw: string): Partial<BookmarkAttrs> {
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && typeof parsed.url === 'string') {
+      return {
+        url: parsed.url,
+        title: typeof parsed.title === 'string' ? parsed.title : '',
+        description: typeof parsed.description === 'string' ? parsed.description : '',
+        icon: typeof parsed.icon === 'string' ? parsed.icon : '',
+        cover: typeof parsed.cover === 'string' ? parsed.cover : '',
+        siteName: typeof parsed.siteName === 'string' ? parsed.siteName : '',
+      }
+    }
+  } catch {
+    // fall through: treat the raw content as a bare URL
+  }
+  const url = raw.trim()
+  return /^https?:\/\//.test(url) ? { url } : {}
+}
+
+function serializeBookmarkPayload(attrs: Record<string, unknown>): string {
+  const payload: Record<string, string> = { url: String(attrs.url ?? '') }
+  for (const key of ['title', 'description', 'icon', 'cover', 'siteName'] as const) {
+    const value = attrs[key]
+    if (typeof value === 'string' && value) {
+      payload[key] = value
+    }
+  }
+  return JSON.stringify(payload, null, 2)
+}
+
+function BookmarkCardView({ node, updateAttributes, editor, getPos, deleteNode }: ReactNodeViewProps) {
+  const t = useTranslations('editor.bookmark')
+  const { url, title, description, icon, cover, siteName, status } = node.attrs as BookmarkAttrs
+  const [coverFailed, setCoverFailed] = useState(false)
+  const [iconFailed, setIconFailed] = useState(false)
+  const fetchingRef = useRef(false)
+
+  const fetchMetadata = useCallback(async () => {
+    if (fetchingRef.current || !url) {
+      return
+    }
+    fetchingRef.current = true
+    try {
+      const result = await capturePublicWebPage(url, { timeoutMs: 20000 })
+      const fetchedTitle = result.title?.trim() || ''
+      if (fetchedTitle && result.status !== 'failed' && result.status !== 'blocked') {
+        updateAttributes({
+          title: fetchedTitle,
+          description: result.excerpt?.trim() || '',
+          siteName: result.siteName?.trim() || '',
+          cover: result.imageUrl || '',
+          icon: getFaviconUrl(result.finalUrl || url),
+          status: 'ready',
+        })
+      } else {
+        updateAttributes({ status: 'error' })
+      }
+    } catch {
+      updateAttributes({ status: 'error' })
+    } finally {
+      fetchingRef.current = false
+    }
+  }, [url, updateAttributes])
+
+  useEffect(() => {
+    if (status === 'loading' && editor.isEditable) {
+      void fetchMetadata()
+    }
+  }, [status, editor.isEditable, fetchMetadata])
+
+  const handleOpen = useCallback(() => {
+    if (url) {
+      void openUrl(url).catch(() => {})
+    }
+  }, [url])
+
+  const handleRefresh = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation()
+    setCoverFailed(false)
+    setIconFailed(false)
+    updateAttributes({ status: 'loading' })
+  }, [updateAttributes])
+
+  const handleConvertToLink = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation()
+    const pos = typeof getPos === 'function' ? getPos() : null
+    if (pos == null) {
+      return
+    }
+    const label = title || url
+    deleteNode()
+    editor
+      .chain()
+      .focus()
+      .insertContentAt(pos, {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: label,
+            marks: [{ type: 'link', attrs: { href: url } }],
+          },
+        ],
+      })
+      .run()
+  }, [editor, getPos, deleteNode, title, url])
+
+  const domain = getDomain(url)
+
+  return (
+    <NodeViewWrapper className="bookmark-card-wrapper my-3" data-drag-handle>
+      <div
+        className={cn(
+          'group relative flex cursor-pointer overflow-hidden rounded-lg border border-border bg-card transition-colors hover:bg-accent/40',
+          status === 'loading' && 'cursor-default'
+        )}
+        onClick={status === 'loading' ? undefined : handleOpen}
+        role="link"
+        title={url}
+      >
+        {status === 'loading' ? (
+          <div className="flex min-h-16 flex-1 items-center gap-2 px-4 py-3 text-sm text-muted-foreground">
+            <LoaderCircle className="size-4 shrink-0 animate-spin" />
+            <span className="truncate">{t('loading', { url })}</span>
+          </div>
+        ) : (
+          <>
+            <div className="min-w-0 flex-1 px-4 py-3">
+              <p className="truncate text-sm font-medium text-foreground">
+                {title || domain}
+              </p>
+              {status === 'error' ? (
+                <p className="mt-1 text-xs text-muted-foreground">{t('fetchFailed')}</p>
+              ) : description ? (
+                <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{description}</p>
+              ) : null}
+              <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+                {icon && !iconFailed ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={icon}
+                    alt=""
+                    className="size-3.5 shrink-0 rounded-sm"
+                    onError={() => setIconFailed(true)}
+                  />
+                ) : (
+                  <Globe className="size-3.5 shrink-0" />
+                )}
+                <span className="truncate">{siteName || domain}</span>
+              </div>
+            </div>
+            {cover && !coverFailed && status === 'ready' ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={cover}
+                alt=""
+                className="hidden max-h-28 w-40 shrink-0 object-cover sm:block"
+                onError={() => setCoverFailed(true)}
+              />
+            ) : null}
+          </>
+        )}
+
+        {editor.isEditable && status !== 'loading' && (
+          <div className="absolute top-1.5 right-1.5 flex gap-0.5 rounded-md bg-card/90 opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleRefresh}
+              title={t('refresh')}
+            >
+              <RefreshCw className="size-3.5" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleConvertToLink}
+              title={t('toLink')}
+            >
+              <Link2 className="size-3.5" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </NodeViewWrapper>
+  )
+}
+
+export const BookmarkCard = Node.create({
+  name: 'bookmarkCard',
+  group: 'block',
+  atom: true,
+
+  addAttributes() {
+    return {
+      url: { default: '' },
+      title: { default: '' },
+      description: { default: '' },
+      icon: { default: '' },
+      cover: { default: '' },
+      siteName: { default: '' },
+      status: { default: 'ready' },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="bookmark-card"]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'bookmark-card' })]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(BookmarkCardView)
+  },
+
+  addCommands() {
+    return {
+      insertBookmarkCard: (url: string) => ({ chain }) => {
+        if (!/^https?:\/\//.test(url)) {
+          return false
+        }
+        return chain()
+          .insertContent({ type: this.name, attrs: { url, status: 'loading' } })
+          .run()
+      },
+      convertLinkToBookmark: () => ({ editor, state, chain }) => {
+        const linkMarkType = state.schema.marks.link
+        if (!linkMarkType) {
+          return false
+        }
+        const { selection } = state
+        const range: Range | void =
+          getMarkRange(selection.$from, linkMarkType) || getMarkRange(selection.$to, linkMarkType)
+        if (!range) {
+          return false
+        }
+        const href = editor.getAttributes('link').href
+        if (typeof href !== 'string' || !/^https?:\/\//.test(href.trim())) {
+          return false
+        }
+        return chain()
+          .focus()
+          .deleteRange(range)
+          .insertContentAt(range.from, {
+            type: this.name,
+            attrs: { url: href.trim(), status: 'loading' },
+          })
+          .run()
+      },
+    }
+  },
+
+  markdownTokenName: 'bookmark',
+
+  markdownTokenizer: {
+    name: 'bookmark',
+    level: 'block',
+    start: (src: string) => {
+      const match = src.match(/^```bookmark\r?\n/)
+      return match ? (match.index ?? -1) : -1
+    },
+    tokenize: (src) => {
+      const match = /^```bookmark\r?\n([\s\S]*?)\r?\n```/.exec(src)
+      if (!match) return undefined
+
+      return {
+        type: 'bookmark',
+        raw: match[0],
+        content: match[1],
+      }
+    },
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  renderMarkdown(node, _helpers) {
+    return `\n\`\`\`bookmark\n${serializeBookmarkPayload(node.attrs ?? {})}\n\`\`\`\n`
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  parseMarkdown(token, _helpers) {
+    const attrs = parseBookmarkPayload(token.content || '')
+    if (!attrs.url) {
+      return { type: 'paragraph', content: [] }
+    }
+    return {
+      type: 'bookmarkCard',
+      attrs: {
+        ...attrs,
+        // Cards saved before metadata arrived resume fetching on open.
+        status: attrs.title ? 'ready' : 'loading',
+      },
+    }
+  },
+})
+
+export default BookmarkCard

--- a/src/app/core/main/editor/markdown/bubble-menu.tsx
+++ b/src/app/core/main/editor/markdown/bubble-menu.tsx
@@ -717,7 +717,7 @@ export function BubbleMenu({
             <ToolbarButton onClick={openCurrentLink} title={t('bubbleMenu.openLink')}><ExternalLink /></ToolbarButton>
             {/^https?:\/\//.test(currentLinkHref) && (
               <ToolbarButton
-                onClick={() => editor.chain().convertLinkToBookmark().run()}
+                onClick={() => document.dispatchEvent(new CustomEvent('tiptap-current-link-to-bookmark'))}
                 title={t('bubbleMenu.pasteAsCard')}
               >
                 <PanelTop />

--- a/src/app/core/main/editor/markdown/bubble-menu.tsx
+++ b/src/app/core/main/editor/markdown/bubble-menu.tsx
@@ -13,6 +13,7 @@ import {
   List,
   ListOrdered,
   CheckSquare,
+  PanelTop,
   Sparkles,
   Minimize2,
   Maximize2,
@@ -714,6 +715,14 @@ export function BubbleMenu({
           <>
             <ToolbarSeparator />
             <ToolbarButton onClick={openCurrentLink} title={t('bubbleMenu.openLink')}><ExternalLink /></ToolbarButton>
+            {/^https?:\/\//.test(currentLinkHref) && (
+              <ToolbarButton
+                onClick={() => editor.chain().convertLinkToBookmark().run()}
+                title={t('bubbleMenu.pasteAsCard')}
+              >
+                <PanelTop />
+              </ToolbarButton>
+            )}
           </>
         )}
       </div>

--- a/src/app/core/main/editor/markdown/tiptap-editor.tsx
+++ b/src/app/core/main/editor/markdown/tiptap-editor.tsx
@@ -2462,11 +2462,34 @@ export function TipTapEditor({
       void openLink(href.trim()).catch(() => {})
     }
 
+    // 链接转书签卡片：兼容 link mark 与 [文本](url) 源码编辑态两种状态
+    const handleCurrentLinkToBookmark = () => {
+      const range = editableLinkSourcePluginKey.getState(editor.state)
+      if (range) {
+        const source = editor.state.doc.textBetween(range.from, range.to, undefined, '￼')
+        const href = parseMarkdownLinkSource(source)?.href?.trim() ?? ''
+        if (!/^https?:\/\//.test(href)) return
+        editor.view.dispatch(editor.state.tr.setMeta(editableLinkSourcePluginKey, null))
+        editor
+          .chain()
+          .focus()
+          .deleteRange({ from: range.from, to: range.to })
+          .insertContentAt(range.from, {
+            type: 'bookmarkCard',
+            attrs: { url: href, status: 'loading' },
+          })
+          .run()
+        return
+      }
+      editor.chain().convertLinkToBookmark().run()
+    }
+
     editorElement.addEventListener('mousedown', handleModifiedMouseDown, true)
     editorElement.addEventListener('click', handleClick)
     document.addEventListener('keydown', handleEscape, true)
     document.addEventListener('tiptap-editable-link-toggle-mark', handleEditableLinkMarkToggle)
     document.addEventListener('tiptap-current-link-open', handleCurrentLinkOpen)
+    document.addEventListener('tiptap-current-link-to-bookmark', handleCurrentLinkToBookmark)
     editor.on('transaction', handleTransaction)
     editor.on('selectionUpdate', expandLinkAtCaret)
     editor.on('blur', handleBlur)
@@ -2477,6 +2500,7 @@ export function TipTapEditor({
       document.removeEventListener('keydown', handleEscape, true)
       document.removeEventListener('tiptap-editable-link-toggle-mark', handleEditableLinkMarkToggle)
       document.removeEventListener('tiptap-current-link-open', handleCurrentLinkOpen)
+      document.removeEventListener('tiptap-current-link-to-bookmark', handleCurrentLinkToBookmark)
       editor.off('transaction', handleTransaction)
       editor.off('selectionUpdate', expandLinkAtCaret)
       editor.off('blur', handleBlur)

--- a/src/app/core/main/editor/markdown/tiptap-editor.tsx
+++ b/src/app/core/main/editor/markdown/tiptap-editor.tsx
@@ -30,6 +30,7 @@ import { dropPoint } from '@tiptap/pm/transform'
 import 'katex/dist/katex.min.css'
 import { InlineMath, BlockMath } from './math-extension'
 import { MermaidDiagram } from './mermaid-extension'
+import { BookmarkCard } from './bookmark-extension'
 import { MathEditorDialog } from './math-editor-dialog'
 import { SearchReplacePanel } from './search-replace-panel'
 import { useEffect, useLayoutEffect, useRef, useCallback, useMemo, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type UIEvent as ReactUIEvent } from 'react'
@@ -768,6 +769,23 @@ const PasteMarkdown = Extension.create({
               return true
             }
 
+            // 粘贴纯 URL：插入链接并选中，触发气泡菜单（可选择打开链接/转为卡片）
+            const trimmedUrl = text.trim()
+            if (/^https?:\/\/\S+$/.test(trimmedUrl)) {
+              const from = selection.from
+              editor
+                .chain()
+                .focus()
+                .insertContent({
+                  type: 'text',
+                  text: trimmedUrl,
+                  marks: [{ type: 'link', attrs: { href: trimmedUrl } }],
+                })
+                .setTextSelection({ from, to: from + trimmedUrl.length })
+                .run()
+              return true
+            }
+
             // 检查文本是否看起来像 Markdown
             if (looksLikeMarkdown(text)) {
               // 使用 editor.commands.insertContent 插入 Markdown 内容
@@ -1428,6 +1446,7 @@ export function TipTapEditor({
       InlineMath,
       BlockMath,
       MermaidDiagram,
+      BookmarkCard,
       Image.extend({
         addAttributes() {
           return {

--- a/src/components/markdown/streamdown-renderer.tsx
+++ b/src/components/markdown/streamdown-renderer.tsx
@@ -61,6 +61,62 @@ function escapeHtml(value: string) {
     .replace(/'/g, '&#39;')
 }
 
+function isBookmarkPayload(code: string): boolean {
+  try {
+    const parsed = JSON.parse(code)
+    return Boolean(parsed) && typeof parsed === 'object' && typeof parsed.url === 'string'
+  } catch {
+    return false
+  }
+}
+
+function StreamdownBookmarkCard({ code }: { code: string }) {
+  const bookmark = useMemo(() => {
+    try {
+      const parsed = JSON.parse(code)
+      if (parsed && typeof parsed === 'object' && typeof parsed.url === 'string') {
+        return parsed as { url: string; title?: string; description?: string; icon?: string; siteName?: string; cover?: string }
+      }
+    } catch {
+      // fall through to null: render as a plain code block
+    }
+    return null
+  }, [code])
+
+  if (!bookmark) {
+    return null
+  }
+
+  let domain = bookmark.url
+  try {
+    domain = new URL(bookmark.url).hostname
+  } catch {
+    // keep the raw url as the label
+  }
+
+  return (
+    <a
+      href={bookmark.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="not-prose flex overflow-hidden rounded-lg border border-border bg-card no-underline transition-colors hover:bg-accent/40"
+      title={bookmark.url}
+    >
+      <span className="min-w-0 flex-1 px-4 py-3">
+        <span className="block truncate text-sm font-medium text-foreground">{bookmark.title || domain}</span>
+        {bookmark.description ? (
+          <span className="mt-1 line-clamp-2 block text-xs text-muted-foreground">{bookmark.description}</span>
+        ) : null}
+        <span className="mt-2 block truncate text-xs text-muted-foreground">{bookmark.siteName || domain}</span>
+      </span>
+      {bookmark.cover ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={bookmark.cover} alt="" className="hidden max-h-28 w-40 shrink-0 object-cover sm:block" />
+      ) : null}
+    </a>
+  )
+}
+
 function StreamdownCode({
   children,
   className,
@@ -82,6 +138,10 @@ function StreamdownCode({
       return escapeHtml(code)
     }
   }, [code, dataBlock, language])
+
+  if (dataBlock && language === 'bookmark' && isBookmarkPayload(code)) {
+    return <StreamdownBookmarkCard code={code} />
+  }
 
   if (!dataBlock) {
     return (


### PR DESCRIPTION
## 功能说明

粘贴链接时可像 Notion 一样将其转换为书签卡片，自动抓取网页标题、描述、站点名与封面图。

- 在编辑器中粘贴纯 URL 时，自动插入为链接并选中，气泡菜单浮窗随即弹出，在"打开链接"右侧新增"粘贴为卡片"按钮
- 光标停在任何已有 http(s) 链接上（包括点击链接后的 `[文本](url)` 源码编辑态）时，同样可通过该按钮转换
- 卡片展示标题、描述（两行截断）、favicon + 站点名，右侧为 og:image 封面（无则隐藏）；点击卡片用系统浏览器打开
- 卡片悬停操作：刷新元数据 / 转回普通链接

## 实现

- **存储格式**：由于笔记为 .md 文件，卡片以 ` ```bookmark ` 代码块内嵌 JSON（url/title/description/icon/cover/siteName）形式存储，Markdown 往返无损，元数据本地化、打开文件无需重新联网；在其他渲染器中降级为代码块显示
- **节点扩展**：新增 `bookmarkCard`（`bookmark-extension.tsx`），结构参照现有 mermaid 扩展（atom 节点 + NodeView + markdownTokenizer/renderMarkdown/parseMarkdown）
- **元数据抓取**：复用现有 `capturePublicWebPage()`（20s 超时）；抓取失败（登录墙/验证码等）降级为域名简卡片并可点刷新重试；保存时尚未完成抓取的卡片，下次打开文件自动续抓
- **预览/导出**：`StreamdownRenderer` 注册了 bookmark 代码块渲染，预览与 PDF 导出显示同样式卡片（JSON 非法时降级为普通代码块）
- 补充 en / zh / zh-TW / ja / pt-BR 五种语言文案

## 测试

- 粘贴纯 URL → 浮窗 → 转卡片、已有链接与源码编辑态转卡片、刷新、转回链接、保存重开续抓均已在本地应用中验证
- `tsc --noEmit` / eslint 通过

## 截图

<img width="792" height="479" alt="image" src="https://github.com/user-attachments/assets/90a05b0b-21b2-4448-8ca3-be104cc7a212" />
<img width="1202" height="688" alt="image" src="https://github.com/user-attachments/assets/4a6b9982-080b-46a8-8baa-2030e3ca9572" />

