### PR TITLE
feat: add OrcaRouter as a built-in AI provider template

### DIFF
--- a/config/config-manifest.json
+++ b/config/config-manifest.json
@@ -1,15 +1,15 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-16T00:00:00Z",
+  "updatedAt": "2026-08-20T00:00:00Z",
   "configs": {
     "providerTemplates": {
-      "versionCode": 105,
-      "versionName": "1.0.5",
+      "versionCode": 106,
+      "versionName": "1.0.6",
       "url": "https://download.notegen.top/config/v1/provider-templates.json"
     },
     "providerTemplatesChina": {
-      "versionCode": 105,
-      "versionName": "1.0.5-cn",
+      "versionCode": 106,
+      "versionName": "1.0.6-cn",
       "url": "https://download.notegen.top/config/v1/provider-templates-cn.json"
     },
     "noteGenDefaultModels": {

--- a/config/provider-templates-cn.json
+++ b/config/provider-templates-cn.json
@@ -151,6 +151,14 @@
       "enabled": true
     },
     {
+      "key": "orcarouter",
+      "title": "OrcaRouter",
+      "baseURL": "https://api.orcarouter.ai/v1",
+      "apiKeyUrl": "https://www.orcarouter.ai",
+      "icon": "https://www.orcarouter.ai/apple-touch-icon.png",
+      "enabled": true
+    },
+    {
       "key": "qiniu",
       "title": "七牛云",
       "baseURL": "https://openai.qiniu.com/v1",

--- a/config/provider-templates.json
+++ b/config/provider-templates.json
@@ -159,6 +159,14 @@
       "enabled": true
     },
     {
+      "key": "orcarouter",
+      "title": "OrcaRouter",
+      "baseURL": "https://api.orcarouter.ai/v1",
+      "apiKeyUrl": "https://www.orcarouter.ai",
+      "icon": "https://www.orcarouter.ai/apple-touch-icon.png",
+      "enabled": true
+    },
+    {
       "key": "qiniu",
       "title": "七牛云",
       "baseURL": "https://openai.qiniu.com/v1",


### PR DESCRIPTION
## What

Add **OrcaRouter** as a built-in AI provider template in NoteGen's AI settings.

Users can now pick **OrcaRouter** from the provider list (alongside OpenRouter, DeepSeek, Grok, etc.), and the base URL `https://api.orcarouter.ai/v1` plus the OrcaRouter API key page link are filled in automatically.

**[OrcaRouter](https://www.orcarouter.ai)** is an OpenAI-compatible gateway that gives you one API key to access 200+ frontier and open-weight models. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `config/provider-templates.json` — add `orcarouter` provider entry (base URL `https://api.orcarouter.ai/v1`, key page `https://www.orcarouter.ai`, icon from `www.orcarouter.ai/apple-touch-icon.png`), mirroring the existing OpenRouter entry.
- `config/provider-templates-cn.json` — same entry for the China storefront config.
- `config/config-manifest.json` — bump provider-templates version to `1.0.6` so clients refetch the updated list (same flow as the previous provider addition in #1196).

## Verification

- JSON files validated (all entries pass NoteGen's provider-template normalization filters).
- `tsc --noEmit` — clean.
- `next lint` — no warnings or errors.
- Live test: `POST https://api.orcarouter.ai/v1/chat/completions` with model `orcarouter/auto` → `HTTP 200`, response `ORCA-OK`; `GET /v1/models` → `HTTP 200`; icon URL reachable.

Disclosure: I'm an engineer on the OrcaRouter team.
