### PR TITLE
fix(i18n): translate remaining Chinese strings in en.json / fix(i18n): 翻译 en.json 中剩余的中文字符串

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2918,9 +2918,9 @@
         "organizeAs": "Organize as",
         "template": "Template",
         "setting": "Settings",
-        "confirm": "确认",
-        "cancel": "取消",
-        "removeThinking": "移除思考过程",
+        "confirm": "Confirm",
+        "cancel": "Cancel",
+        "removeThinking": "Remove thinking process",
         "stop": "Stop"
       }
     },
@@ -2951,11 +2951,11 @@
         "noMatchingConversations": "No matching conversations found",
         "noConversationHistory": "No conversation history yet",
         "quickPrompts": {
-          "title": "快速开始",
-          "writeNote": "帮我写一篇笔记",
-          "summarize": "帮我总结这段内容",
-          "brainstorm": "帮我头脑风暴一些想法",
-          "explain": "帮我解释这个概念"
+          "title": "Quick start",
+          "writeNote": "Help me write a note",
+          "summarize": "Help me summarize this content",
+          "brainstorm": "Help me brainstorm some ideas",
+          "explain": "Help me explain this concept"
         }
       },
       "newChat": "New Chat with New Tag",


### PR DESCRIPTION
I noticed some strings in the Quick Start section and settings were still in Chinese when using the English UI. This PR translates them to English.

嗨！我注意到在使用英文界面时，“快速开始”部分和设置里的一些字符串仍然是中文。这个 PR 将它们翻译成了英文。