### PR TITLE
fix(ai): guard against stream chunks that have no choices array

### DIFF
--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -1279,7 +1279,7 @@ export class AgentRuntime {
           if (this.stopped) {
             throw new Error('USER_STOPPED')
           }
-          const choice = chunk.choices[0]
+          const choice = chunk.choices?.[0]
           if (!choice) {
             continue
           }

--- a/src/lib/ai/chat.ts
+++ b/src/lib/ai/chat.ts
@@ -191,7 +191,7 @@ export async function fetchAiStream(
         break;
       }
       
-      const delta = chunk.choices[0]?.delta
+      const delta = chunk.choices?.[0]?.delta
       const extendedDelta = delta as (typeof delta & {
         reasoning?: string
         reasoning_content?: string
@@ -392,7 +392,7 @@ export async function fetchAiStream(
             break;
           }
           
-          const delta = chunk.choices[0]?.delta
+          const delta = chunk.choices?.[0]?.delta
           const extendedDelta = delta as (typeof delta & {
             reasoning?: string
             reasoning_content?: string
@@ -506,7 +506,7 @@ export async function fetchAiStreamToken(text: string, onUpdate: (content: strin
         break;
       }
       
-      const content = chunk.choices[0]?.delta?.content || ''
+      const content = chunk.choices?.[0]?.delta?.content || ''
       if (content) {
         onUpdate(content)
       }

--- a/src/lib/ai/completion.ts
+++ b/src/lib/ai/completion.ts
@@ -208,7 +208,7 @@ Continuation:`
 
     let isFirst = true
     for await (const chunk of stream) {
-      const content = chunk.choices[0]?.delta?.content
+      const content = chunk.choices?.[0]?.delta?.content
       if (content) {
         const cleaned = cleanupCompletion(content)
         if (cleaned) {
@@ -265,7 +265,7 @@ export async function fetchEditorAiGenerationStream(
 
     let isFirst = true
     for await (const chunk of stream) {
-      const content = chunk.choices[0]?.delta?.content
+      const content = chunk.choices?.[0]?.delta?.content
       if (content) {
         onChunk(content, isFirst)
         isFirst = false

--- a/src/lib/ai/rewrite.ts
+++ b/src/lib/ai/rewrite.ts
@@ -165,7 +165,7 @@ Output:`
 
     let isFirst = true
     for await (const chunk of stream) {
-      const delta = chunk.choices[0]?.delta
+      const delta = chunk.choices?.[0]?.delta
       const rawThinking = (delta as { reasoning_content?: string } | undefined)?.reasoning_content || ''
       const content = delta?.content || ''
 
@@ -247,7 +247,7 @@ Output:`
 
     let isFirst = true
     for await (const chunk of stream) {
-      const delta = chunk.choices[0]?.delta
+      const delta = chunk.choices?.[0]?.delta
       const rawThinking = (delta as { reasoning_content?: string } | undefined)?.reasoning_content || ''
       const content = delta?.content || ''
 
@@ -329,7 +329,7 @@ Output:`
 
     let isFirst = true
     for await (const chunk of stream) {
-      const delta = chunk.choices[0]?.delta
+      const delta = chunk.choices?.[0]?.delta
       const rawThinking = (delta as { reasoning_content?: string } | undefined)?.reasoning_content || ''
       const content = delta?.content || ''
 

--- a/src/lib/ai/translate.ts
+++ b/src/lib/ai/translate.ts
@@ -77,7 +77,7 @@ export async function fetchAiTranslateStream(
 
     let isFirst = true
     for await (const chunk of stream) {
-      const delta = chunk.choices[0]?.delta
+      const delta = chunk.choices?.[0]?.delta
       const rawThinking = (delta as { reasoning_content?: string } | undefined)?.reasoning_content || ''
       const content = delta?.content || ''
 


### PR DESCRIPTION
## Problem

Every streaming loop reads `chunk.choices[0]` directly. If a provider emits a chunk
without a `choices` array, that throws before any of the existing guards run:

```
TypeError: undefined is not an object (evaluating 'e.choices[0]')
```

The existing optional chaining does not help, because it sits *after* the index:

```ts
const delta = chunk.choices[0]?.delta   // still throws if `choices` is undefined
```

In `src/lib/agent/runtime.ts` the `if (!choice) continue` guard on the next line is
likewise unreachable for this case.

## How I hit it

Running against a local LM Studio server (OpenAI-compatible endpoint). The first
request after the model had been evicted triggered a cold load of a 12GB model
(~13s on a CPU-only host). The client aborted mid-load, and the aborted stream
produced a chunk with no `choices`, which killed the whole agent run with the error
above instead of ending the stream cleanly.

Server-side log for that request:

```
POST /v1/chat/completions
load_model: .../gpt-oss-20b-MXFP4.gguf
model loaded                       (13s later)
Client disconnected. Stopping generation...
```

This is not specific to LM Studio — any provider or proxy that emits a keepalive,
error, or terminal frame without `choices` will do the same.

## Fix

Move the optional chaining before the index: `chunk.choices?.[0]`.

10 call sites across 5 files. No behavior change on well-formed chunks: every site
already handles an `undefined` result on the next line, so this only lets those
existing guards do their job.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rsgamahFqrfNUZqAHceG1
