### PR TITLE
fix(agent): emit `items` for array tool parameters

### DIFF
--- a/src/lib/agent/tool-registry.ts
+++ b/src/lib/agent/tool-registry.ts
@@ -211,11 +211,20 @@ function legacyInputSchema(tool: Tool): JsonSchema {
   const required: string[] = []
 
   for (const parameter of tool.parameters) {
-    properties[parameter.name] = {
+    const schema: JsonSchema = {
       type: parameter.type === 'number' ? 'number' : parameter.type,
       description: parameter.description,
       default: parameter.default,
     }
+
+    // JSON Schema requires `items` alongside `type: 'array'`. Legacy tool
+    // descriptors carry no item type, so emit a permissive schema rather than a
+    // bare `{ "type": "array" }`, which some providers reject outright.
+    if (schema.type === 'array' && schema.items === undefined) {
+      schema.items = {}
+    }
+
+    properties[parameter.name] = schema
 
     if (parameter.required) {
       required.push(parameter.name)


### PR DESCRIPTION
## Problem

`legacyInputSchema()` copies a tool parameter's `type` straight into the generated
JSON Schema, so an `array` parameter is emitted with no `items`:

```jsonc
{ "type": "array", "description": "Array of tags to create, ..." }
```

`items` is required alongside `type: "array"`, and some providers reject it outright
rather than ignoring it. Against a local LM Studio server, every agent request fails
because the model's chat template cannot render the tool list:

```
[ERROR][openai/gpt-oss-20b] Engine protocol predict request returned 500:
While executing If at line 12, column 13 in source:
...am_spec.type == "array" -%}
    {%- if param_spec['items'] -%}
Error: Function is not a bool value
```

The template tests `param_spec['items']`; with the key absent that resolves to the
mapping's `items` method rather than a value, which is not a bool — so the whole
request 500s before generation starts.

Minimal reproduction against `/v1/chat/completions`, same model, only the schema differs:

```jsonc
// 500 server_error
{"type": "object", "properties": {"tags": {"type": "array", "description": "d"}}}

// 200 OK
{"type": "object", "properties": {"tags": {"type": "array", "description": "d", "items": {}}}}
```

At least 19 tool parameters across `tag-tools`, `note-tools`, `mark-tools`,
`folder-tools`, `chat-tools` and `system-tools` declare `type: 'array'`, so in practice
the agent is unusable with any provider strict about this.

## Fix

Emit a permissive `items: {}` when an array parameter has none. `ToolParameter` carries
no item type, so `{}` (any item) is used rather than guessing `string` — several of these
arrays hold objects, and asserting the wrong item type would be worse than asserting none.

Models that already tolerated the missing key (Qwen 3 among others) are unaffected;
this only adds a key that JSON Schema requires.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rsgamahFqrfNUZqAHceG1
