### PR TITLE
fix(#1244): 修复 Linux 下重复显示标题栏

### DIFF
--- a/src-tauri/src/app_setup.rs
+++ b/src-tauri/src/app_setup.rs
@@ -5,7 +5,7 @@ use crate::tray::create_tray;
 use crate::web_clipper;
 use crate::window;
 use tauri::App;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 use tauri::Manager;
 
 pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
@@ -13,8 +13,8 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
 
     cleanup_temp_screenshot_dir(&app_handle);
 
-    // 在 Windows 上明确禁用窗口装饰
-    #[cfg(target_os = "windows")]
+    // 在 Windows 和 Linux 上明确禁用系统窗口装饰，使用自定义标题栏
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     {
         if let Some(window) = app_handle.get_webview_window("main") {
             let _ = window.set_decorations(false);


### PR DESCRIPTION
## 修改说明

- Linux 主窗口启动时关闭系统窗口装饰，避免与 NoteGen 自定义标题栏重复显示
- 保留现有拖拽区域及最小化、最大化、关闭按钮行为
- Windows 继续沿用原逻辑，macOS 和移动端不受影响

## 验证

- `git diff --cached --check` 通过
- 按项目要求未运行测试、Lint、类型检查或构建
- 当前环境为 macOS，未完成 Linux 实机 UI 验证

关联 #1244